### PR TITLE
Feat/admin back (#81)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # ==========================================
 # Node.js Alpine Backend Dockerfile
 # Build with Bun, Run with Node.js for AWS SDK compatibility

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,6 +20,11 @@ model User {
   folders       Folder[]
   authProvider  String   // e.g., cognito, credentials, oauth
   role          String   // e.g., user, admin
+  
+  // Suspend/Ban 관련
+  isBanned      Boolean  @default(false)
+  banReason     String?
+  suspendedUntil DateTime?
 
   // Back-relations
   uploads                Upload[]     @relation("UserUploads")
@@ -32,6 +37,12 @@ model User {
   
   // Sharing relations
   collaborations         NoteCollaborator[]
+  
+  // Subscription relations
+  subscriptions         Subscription[]
+  
+  @@index([isBanned])
+  @@index([suspendedUntil])
 }
 
 model Folder {
@@ -494,4 +505,61 @@ model TrustedDevice {
 
   @@index([userId])
   @@index([fingerprint])
+}
+
+// === Subscription & Plans ===
+
+// Plan (요금제)
+model Plan {
+  id            String   @id @default(cuid())
+  name          String   @unique
+  description   String
+  monthlyPrice  Int      @default(0) // 원 단위
+  yearlyPrice   Int      @default(0) // 원 단위
+  status        String   @default("active") // active, inactive, deprecated
+  features      Json     // PlanFeature[] 형식
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  
+  subscriptions Subscription[]
+  
+  @@index([status])
+}
+
+// Subscription (구독)
+model Subscription {
+  id                  String   @id @default(cuid())
+  userId              String
+  planId              String
+  status              String   @default("active") // active, cancelled, past_due
+  amount              Int      // 현재 구독 금액 (원)
+  billingCycle        String   // monthly, yearly
+  currentPeriodStart  DateTime
+  currentPeriodEnd    DateTime
+  cancelledAt         DateTime?
+  cancelReason        String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+  
+  user                User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  plan                Plan     @relation(fields: [planId], references: [id])
+  
+  @@unique([userId, planId])
+  @@index([userId])
+  @@index([planId])
+  @@index([status])
+  @@index([currentPeriodEnd])
+}
+
+// === System Settings ===
+
+// SystemSettings (시스템 설정)
+model SystemSettings {
+  id        String   @id @default(cuid())
+  key       String   @unique  // 설정 키 (예: 'general', 'security')
+  value     Json     // 설정 값 (JSON 형식)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  
+  @@index([key])
 }

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from './guards';
+import { CurrentUser } from '../common/current-user.decorator';
+import { AdminService } from './admin.service';
+import { AdminUserResponseDto } from './dto';
+
+/**
+ * Admin Controller
+ * Base URL: /api/admin
+ * 
+ * 모든 엔드포인트는 JWT 인증 + Admin/Operator 역할 필요
+ */
+@ApiTags('Admin')
+@ApiBearerAuth()
+@Controller('admin')
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+export class AdminController {
+  private readonly logger = new Logger(AdminController.name);
+
+  constructor(private readonly adminService: AdminService) {}
+
+  /**
+   * 현재 관리자 사용자 정보 조회
+   * GET /api/admin/auth/me
+   */
+  @Get('auth/me')
+  @ApiOperation({
+    summary: '현재 관리자 사용자 정보 조회',
+    description: 'admin 또는 operator 역할을 가진 사용자의 정보를 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자 정보 조회 성공',
+    type: AdminUserResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '권한 부족 (admin 또는 operator 역할 필요)',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자를 찾을 수 없음',
+  })
+  async getMe(
+    @CurrentUser() user: { id: string },
+  ): Promise<{ data: AdminUserResponseDto }> {
+    this.logger.debug(`GET /api/admin/auth/me userId=${user.id}`);
+    const adminUser = await this.adminService.getCurrentAdminUser(user.id);
+    return { data: adminUser };
+  }
+}
+

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -1,0 +1,53 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { DashboardController } from './dashboard.controller';
+import { UsersController } from './users.controller';
+import { PlansController } from './plans.controller';
+import { SubscriptionsController } from './subscriptions.controller';
+import { MonitoringController } from './monitoring.controller';
+import { SettingsController } from './settings.controller';
+import { AdminService } from './admin.service';
+import { DashboardService } from './dashboard.service';
+import { UsersService } from './users.service';
+import { PlansService } from './plans.service';
+import { SubscriptionsService } from './subscriptions.service';
+import { MonitoringService } from './monitoring.service';
+import { SettingsService } from './settings.service';
+import { DbModule } from '../db/db.module';
+import { AdminRoleGuard } from './guards/admin-role.guard';
+import { AdminOnlyGuard } from './guards/admin-only.guard';
+
+@Module({
+  imports: [DbModule],
+  controllers: [
+    AdminController,
+    DashboardController,
+    UsersController,
+    PlansController,
+    SubscriptionsController,
+    MonitoringController,
+    SettingsController,
+  ],
+  providers: [
+    AdminService,
+    DashboardService,
+    UsersService,
+    PlansService,
+    SubscriptionsService,
+    MonitoringService,
+    SettingsService,
+    AdminRoleGuard,
+    AdminOnlyGuard,
+  ],
+  exports: [
+    AdminService,
+    DashboardService,
+    UsersService,
+    PlansService,
+    SubscriptionsService,
+    MonitoringService,
+    SettingsService,
+  ],
+})
+export class AdminModule {}
+

--- a/backend/src/modules/admin/admin.service.spec.ts
+++ b/backend/src/modules/admin/admin.service.spec.ts
@@ -1,0 +1,98 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { PrismaService } from '../db/prisma.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let prismaService: any;
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      user: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+    prismaService = module.get(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getCurrentAdminUser', () => {
+    it('should return admin user when user exists', async () => {
+      const mockUser = {
+        id: 'user-001',
+        email: 'admin@test.com',
+        displayName: 'Admin User',
+        role: 'admin',
+        deletedAt: null,
+      };
+
+      prismaService.user.findUnique.mockResolvedValue(mockUser as any);
+
+      const result = await service.getCurrentAdminUser('user-001');
+
+      expect(result).toEqual({
+        id: 'user-001',
+        email: 'admin@test.com',
+        name: 'Admin User',
+        role: 'admin',
+        permissions: expect.any(Array),
+      });
+
+      expect(prismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-001' },
+        select: {
+          id: true,
+          email: true,
+          displayName: true,
+          role: true,
+          deletedAt: true,
+        },
+      });
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      prismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getCurrentAdminUser('non-existent')).rejects.toThrow(
+        NotFoundException,
+      );
+
+      await expect(service.getCurrentAdminUser('non-existent')).rejects.toThrow(
+        '사용자를 찾을 수 없습니다.',
+      );
+    });
+
+    it('should throw NotFoundException when user is deleted', async () => {
+      const deletedUser = {
+        id: 'user-001',
+        email: 'deleted@test.com',
+        displayName: 'Deleted User',
+        role: 'user',
+        deletedAt: new Date(),
+      };
+
+      prismaService.user.findUnique.mockResolvedValue(deletedUser as any);
+
+      await expect(service.getCurrentAdminUser('user-001')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});
+

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../db/prisma.service';
+import { AdminUserResponseDto } from './dto';
+import { AdminErrors } from './constants';
+
+@Injectable()
+export class AdminService {
+  private readonly logger = new Logger(AdminService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 현재 관리자/운영자 사용자 정보 조회
+   * GET /api/admin/auth/me
+   * 
+   * Note: 권한 체크는 AdminRoleGuard에서 이미 수행됨
+   */
+  async getCurrentAdminUser(userId: string): Promise<AdminUserResponseDto> {
+    this.logger.debug(`getCurrentAdminUser userId=${userId}`);
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        displayName: true,
+        role: true,
+        deletedAt: true,
+      },
+    });
+
+    if (!user || user.deletedAt) {
+      throw new NotFoundException(AdminErrors.USER_NOT_FOUND.message);
+    }
+
+    return new AdminUserResponseDto({
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+      role: user.role,
+    });
+  }
+}
+

--- a/backend/src/modules/admin/constants/errors.ts
+++ b/backend/src/modules/admin/constants/errors.ts
@@ -1,0 +1,46 @@
+/**
+ * Admin Error Messages
+ * 관리자 모듈 에러 메시지 상수
+ */
+export const AdminErrors = {
+  AUTHENTICATION_REQUIRED: {
+    code: 'AUTHENTICATION_REQUIRED',
+    message: '인증이 필요합니다.',
+    messageEn: 'Authentication required',
+  },
+  ADMIN_ROLE_REQUIRED: {
+    code: 'ADMIN_ROLE_REQUIRED',
+    message: '관리자 권한이 필요합니다.',
+    messageEn: 'Admin or operator role required',
+  },
+  ADMIN_ONLY_REQUIRED: {
+    code: 'ADMIN_ONLY_REQUIRED',
+    message: '최고 관리자 권한이 필요합니다.',
+    messageEn: 'Admin role required',
+  },
+  INSUFFICIENT_PERMISSIONS: {
+    code: 'INSUFFICIENT_PERMISSIONS',
+    message: '해당 작업을 수행할 권한이 없습니다.',
+    messageEn: 'Insufficient permissions',
+  },
+  USER_NOT_FOUND: {
+    code: 'USER_NOT_FOUND',
+    message: '사용자를 찾을 수 없습니다.',
+    messageEn: 'User not found',
+  },
+} as const;
+
+/**
+ * Helper function to create error response
+ */
+export const createAdminError = (
+  errorKey: keyof typeof AdminErrors,
+  useEnglish = false,
+) => {
+  const error = AdminErrors[errorKey];
+  return {
+    code: error.code,
+    message: useEnglish ? error.messageEn : error.message,
+  };
+};
+

--- a/backend/src/modules/admin/constants/index.ts
+++ b/backend/src/modules/admin/constants/index.ts
@@ -1,0 +1,5 @@
+export * from './roles';
+export * from './permissions';
+export * from './types';
+export * from './errors';
+

--- a/backend/src/modules/admin/constants/permissions.ts
+++ b/backend/src/modules/admin/constants/permissions.ts
@@ -1,0 +1,86 @@
+import { UserRole } from './roles';
+
+/**
+ * Permission Types
+ * 권한 타입 정의
+ */
+export enum Permission {
+  // User Management
+  USER_READ = 'user:read',
+  USER_WRITE = 'user:write',
+  USER_DELETE = 'user:delete',
+
+  // Plan Management
+  PLAN_READ = 'plan:read',
+  PLAN_WRITE = 'plan:write',
+  PLAN_DELETE = 'plan:delete',
+
+  // Subscription Management
+  SUBSCRIPTION_READ = 'subscription:read',
+  SUBSCRIPTION_WRITE = 'subscription:write',
+
+  // Server Monitoring
+  SERVER_READ = 'server:read',
+
+  // System Settings
+  SETTINGS_READ = 'settings:read',
+  SETTINGS_WRITE = 'settings:write',
+
+  // Dashboard
+  DASHBOARD_READ = 'dashboard:read',
+}
+
+/**
+ * Role-based Permission Mapping
+ * 역할별 권한 매핑
+ * 
+ * admin: 모든 권한
+ * operator: 조회 및 제한적인 수정 권한 (삭제, 설정 변경 불가)
+ * user: 권한 없음
+ */
+export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
+  [UserRole.ADMIN]: [
+    Permission.USER_READ,
+    Permission.USER_WRITE,
+    Permission.USER_DELETE,
+    Permission.PLAN_READ,
+    Permission.PLAN_WRITE,
+    Permission.PLAN_DELETE,
+    Permission.SUBSCRIPTION_READ,
+    Permission.SUBSCRIPTION_WRITE,
+    Permission.SERVER_READ,
+    Permission.SETTINGS_READ,
+    Permission.SETTINGS_WRITE,
+    Permission.DASHBOARD_READ,
+  ],
+  [UserRole.OPERATOR]: [
+    Permission.USER_READ,
+    Permission.USER_WRITE,
+    Permission.PLAN_READ,
+    Permission.SUBSCRIPTION_READ,
+    Permission.SERVER_READ,
+    Permission.DASHBOARD_READ,
+  ],
+  [UserRole.USER]: [],
+};
+
+/**
+ * Get permissions by role
+ * 역할에 따른 권한 목록 반환
+ */
+export const getPermissionsByRole = (role: string): string[] => {
+  return ROLE_PERMISSIONS[role as UserRole] || [];
+};
+
+/**
+ * Check if user has permission
+ * 사용자가 특정 권한을 가지고 있는지 확인
+ */
+export const hasPermission = (
+  userRole: string,
+  permission: Permission,
+): boolean => {
+  const permissions = getPermissionsByRole(userRole);
+  return permissions.includes(permission);
+};
+

--- a/backend/src/modules/admin/constants/roles.ts
+++ b/backend/src/modules/admin/constants/roles.ts
@@ -1,0 +1,62 @@
+/**
+ * User Role Enum
+ * 사용자 역할 정의
+ * 
+ * 프론트엔드 타입과 동기화:
+ * - frontend/src/lib/api/types/admin.types.ts
+ * - UserRole = "user" | "operator" | "admin"
+ */
+export enum UserRole {
+  ADMIN = 'admin',
+  OPERATOR = 'operator',
+  USER = 'user',
+}
+
+/**
+ * User Status Enum
+ * 사용자 상태 정의 (프론트엔드와 동기화)
+ */
+export enum UserStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  SUSPENDED = 'suspended',
+  BANNED = 'banned',
+}
+
+/**
+ * 관리자 페이지 접근 가능한 역할
+ * (admin + operator)
+ */
+export const ADMIN_ROLES: readonly UserRole[] = [
+  UserRole.ADMIN,
+  UserRole.OPERATOR,
+] as const;
+
+/**
+ * Admin 전용 역할
+ * (operator는 접근 불가)
+ */
+export const ADMIN_ONLY: readonly UserRole[] = [UserRole.ADMIN] as const;
+
+/**
+ * 역할 확인 헬퍼 함수
+ */
+export const isAdminRole = (role: string): boolean => {
+  return role === UserRole.ADMIN || role === UserRole.OPERATOR;
+};
+
+export const isAdminOnly = (role: string): boolean => {
+  return role === UserRole.ADMIN;
+};
+
+/**
+ * 배열 포함 여부 확인 (타입 안전)
+ */
+export const isInAdminRoles = (role: string): boolean => {
+  return ADMIN_ROLES.some((adminRole) => adminRole === role);
+};
+
+export const isInAdminOnly = (role: string): boolean => {
+  return ADMIN_ONLY.some((adminRole) => adminRole === role);
+};
+

--- a/backend/src/modules/admin/constants/types.ts
+++ b/backend/src/modules/admin/constants/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Request User Type
+ * Express Request에 포함된 사용자 정보 타입
+ */
+export interface RequestUser {
+  id: string;
+  email?: string;
+  role?: string;
+}
+
+/**
+ * Type Guard: RequestUser 확인
+ */
+export const isRequestUser = (user: unknown): user is RequestUser => {
+  return (
+    typeof user === 'object' &&
+    user !== null &&
+    'id' in user &&
+    typeof (user as RequestUser).id === 'string'
+  );
+};
+

--- a/backend/src/modules/admin/dashboard.controller.ts
+++ b/backend/src/modules/admin/dashboard.controller.ts
@@ -1,0 +1,79 @@
+import { Controller, Get, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from './guards';
+import { DashboardService } from './dashboard.service';
+import { DashboardStatsResponseDto, ServerStatusDto } from './dto';
+
+/**
+ * Dashboard Controller
+ * Base URL: /api/admin/dashboard
+ * 
+ * 대시보드 관련 통계 및 정보 조회
+ */
+@ApiTags('Admin')
+@ApiBearerAuth()
+@Controller('admin/dashboard')
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+export class DashboardController {
+  private readonly logger = new Logger(DashboardController.name);
+
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  /**
+   * 대시보드 통계 조회
+   * GET /api/admin/dashboard/stats
+   */
+  @Get('stats')
+  @ApiOperation({
+    summary: '대시보드 통계 조회',
+    description: '전체 사용자 수, 활성 세션, 오늘 가입자 수 등 주요 통계를 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '통계 조회 성공',
+    type: DashboardStatsResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '권한 부족 (admin 또는 operator 역할 필요)',
+  })
+  async getStats(): Promise<{ data: DashboardStatsResponseDto }> {
+    this.logger.debug('GET /api/admin/dashboard/stats');
+    const stats = await this.dashboardService.getDashboardStats();
+    return { data: stats };
+  }
+
+  /**
+   * 서버 상태 목록 조회
+   * GET /api/admin/dashboard/servers
+   */
+  @Get('servers')
+  @ApiOperation({
+    summary: '서버 상태 목록 조회',
+    description: 'API 서버, 데이터베이스, 캐시 등 각 서버의 상태를 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '서버 상태 조회 성공',
+    type: [ServerStatusDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '권한 부족 (admin 또는 operator 역할 필요)',
+  })
+  async getServers(): Promise<{ data: ServerStatusDto[] }> {
+    this.logger.debug('GET /api/admin/dashboard/servers');
+    const servers = await this.dashboardService.getServers();
+    return { data: servers };
+  }
+}
+

--- a/backend/src/modules/admin/dashboard.service.spec.ts
+++ b/backend/src/modules/admin/dashboard.service.spec.ts
@@ -1,0 +1,133 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardService } from './dashboard.service';
+import { PrismaService } from '../db/prisma.service';
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+  let prismaService: any;
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      user: {
+        count: jest.fn(),
+      },
+      refreshToken: {
+        count: jest.fn(),
+        findMany: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DashboardService>(DashboardService);
+    prismaService = module.get(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getDashboardStats', () => {
+    it('should return dashboard statistics', async () => {
+      // Mock counts
+      prismaService.user.count
+        .mockResolvedValueOnce(17948) // totalUsers
+        .mockResolvedValueOnce(15942) // totalUsers 30일 전
+        .mockResolvedValueOnce(156) // todaySignups
+        .mockResolvedValueOnce(160); // todaySignups 어제
+
+      prismaService.refreshToken.findMany
+        .mockResolvedValueOnce(
+          Array.from({ length: 1247 }, (_, i) => ({ userId: `user-${i}` })),
+        ) // activeSessions
+        .mockResolvedValueOnce(
+          Array.from({ length: 1152 }, (_, i) => ({ userId: `user-${i}` })),
+        ); // activeSessions yesterday
+
+      const result = await service.getDashboardStats();
+
+      expect(result.totalUsers).toBe(17948);
+      expect(result.activeSessions).toBe(1247);
+      expect(result.todaySignups).toBe(156);
+      expect(result.systemStatus).toBeDefined();
+      expect(['healthy', 'warning', 'error']).toContain(result.systemStatus);
+    });
+
+    it('should use cache when called within cache TTL', async () => {
+      prismaService.user.count.mockResolvedValue(17948);
+      prismaService.refreshToken.findMany.mockResolvedValue([]);
+
+      // First call
+      await service.getDashboardStats();
+
+      // Second call (should use cache)
+      await service.getDashboardStats();
+
+      // Should only call Prisma once (first time)
+      expect(prismaService.user.count).toHaveBeenCalledTimes(4); // 4 queries in first call
+    });
+
+    it('should handle database errors gracefully', async () => {
+      prismaService.user.count.mockRejectedValue(new Error('DB Error'));
+
+      await expect(service.getDashboardStats()).rejects.toThrow(
+        '대시보드 통계 조회에 실패했습니다.',
+      );
+    });
+  });
+
+  describe('getServers', () => {
+    it('should return server status list', async () => {
+      const result = await service.getServers();
+
+      expect(result).toHaveLength(4);
+      expect(result[0]).toHaveProperty('name');
+      expect(result[0]).toHaveProperty('status');
+      expect(result[0]).toHaveProperty('cpu');
+      expect(result[0]).toHaveProperty('memory');
+      expect(result[0]).toHaveProperty('responseTime');
+      expect(result[0]).toHaveProperty('connections');
+      expect(result[0]).toHaveProperty('lastCheck');
+    });
+
+    it('should include Main API Server', async () => {
+      const result = await service.getServers();
+
+      const mainServer = result.find((s) => s.name === 'Main API Server');
+      expect(mainServer).toBeDefined();
+      expect(mainServer?.status).toBeDefined();
+    });
+
+    it('should return valid status values', async () => {
+      const result = await service.getServers();
+
+      result.forEach((server) => {
+        expect(['healthy', 'warning', 'error']).toContain(server.status);
+      });
+    });
+
+    it('should return valid metric ranges', async () => {
+      const result = await service.getServers();
+
+      result.forEach((server) => {
+        expect(server.cpu).toBeGreaterThanOrEqual(0);
+        expect(server.cpu).toBeLessThanOrEqual(100);
+        expect(server.memory).toBeGreaterThanOrEqual(0);
+        expect(server.memory).toBeLessThanOrEqual(100);
+        expect(server.responseTime).toBeGreaterThan(0);
+        if (server.connections !== undefined) {
+          expect(server.connections).toBeGreaterThanOrEqual(0);
+        }
+      });
+    });
+  });
+});
+

--- a/backend/src/modules/admin/dashboard.service.ts
+++ b/backend/src/modules/admin/dashboard.service.ts
@@ -1,0 +1,347 @@
+import { Injectable, Logger, InternalServerErrorException } from '@nestjs/common';
+import { PrismaService } from '../db/prisma.service';
+import { DashboardStatsResponseDto, SystemStatus } from './dto/dashboard-stats-response.dto';
+import { ServerStatusDto } from './dto/server-status.dto';
+
+@Injectable()
+export class DashboardService {
+  private readonly logger = new Logger(DashboardService.name);
+
+  // 캐싱 (5분)
+  private cache: DashboardStatsResponseDto | null = null;
+  private cacheExpiry: Date | null = null;
+  private readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5분
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 대시보드 통계 조회
+   * GET /api/admin/dashboard/stats
+   */
+  async getDashboardStats(): Promise<DashboardStatsResponseDto> {
+    this.logger.debug('getDashboardStats');
+
+    // 캐시 체크
+    const now = new Date();
+    if (this.cache && this.cacheExpiry && now < this.cacheExpiry) {
+      this.logger.debug('Returning cached dashboard stats');
+      return this.cache;
+    }
+
+    try {
+      // 날짜 계산 (UTC 기준)
+      const nowUtc = new Date();
+      const oneDayAgo = new Date(nowUtc.getTime() - 24 * 60 * 60 * 1000);
+      const twoDaysAgo = new Date(nowUtc.getTime() - 2 * 24 * 60 * 60 * 1000);
+      const thirtyDaysAgo = new Date(nowUtc.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+      const startOfToday = new Date(nowUtc);
+      startOfToday.setUTCHours(0, 0, 0, 0);
+
+      const startOfYesterday = new Date(startOfToday);
+      startOfYesterday.setUTCDate(startOfYesterday.getUTCDate() - 1);
+
+      // 모든 쿼리 병렬 실행
+      const [
+        totalUsers,
+        totalUsersThirtyDaysAgo,
+        activeUserIds,
+        activeUserIdsYesterday,
+        todaySignups,
+        yesterdaySignups,
+      ] = await Promise.all([
+        // 1. 현재 전체 사용자 수
+        this.prisma.user.count({
+          where: { deletedAt: null },
+        }),
+
+        // 2. 30일 전까지 가입한 사용자 수 (30일간 증가분 계산용)
+        this.prisma.user.count({
+          where: {
+            deletedAt: null,
+            createdAt: { lte: thirtyDaysAgo },
+          },
+        }),
+
+        // 3. 최근 24시간 활성 사용자 (고유 사용자, 만료되지 않은 토큰만)
+        this.prisma.refreshToken.findMany({
+          where: {
+            createdAt: { gte: oneDayAgo },
+            expiresAt: { gte: nowUtc },
+            revokedAt: null,
+          },
+          select: { userId: true },
+          distinct: ['userId'],
+        }),
+
+        // 4. 24-48시간 전 활성 사용자
+        this.prisma.refreshToken.findMany({
+          where: {
+            createdAt: {
+              gte: twoDaysAgo,
+              lt: oneDayAgo,
+            },
+            expiresAt: { gte: oneDayAgo },
+            revokedAt: null,
+          },
+          select: { userId: true },
+          distinct: ['userId'],
+        }),
+
+        // 5. 오늘 가입자 수
+        this.prisma.user.count({
+          where: {
+            deletedAt: null,
+            createdAt: { gte: startOfToday },
+          },
+        }),
+
+        // 6. 어제 가입자 수
+        this.prisma.user.count({
+          where: {
+            deletedAt: null,
+            createdAt: {
+              gte: startOfYesterday,
+              lt: startOfToday,
+            },
+          },
+        }),
+      ]);
+
+      // 활성 세션 수 (고유 사용자 수)
+      const activeSessions = activeUserIds.length;
+      const activeSessionsYesterday = activeUserIdsYesterday.length;
+
+      // 변화율 계산
+      const totalUsersChange = this.calculateChangeRate(
+        totalUsersThirtyDaysAgo,
+        totalUsers,
+      );
+
+      const activeSessionsChange = this.calculateChangeRate(
+        activeSessionsYesterday,
+        activeSessions,
+      );
+
+      const todaySignupsChange = this.calculateChangeRate(
+        yesterdaySignups,
+        todaySignups,
+      );
+
+      // 시스템 상태 판단
+      const systemStatus = this.determineSystemStatus({
+        totalUsers,
+        activeSessions,
+        todaySignups,
+      });
+
+      const stats = new DashboardStatsResponseDto({
+        totalUsers,
+        totalUsersChange,
+        activeSessions,
+        activeSessionsChange,
+        todaySignups,
+        todaySignupsChange,
+        systemStatus,
+      });
+
+      // 캐시 저장
+      this.cache = stats;
+      this.cacheExpiry = new Date(nowUtc.getTime() + this.CACHE_TTL_MS);
+
+      return stats;
+    } catch (error) {
+      this.logger.error('Failed to get dashboard stats', error);
+      // 에러 시 캐시 무효화
+      this.cache = null;
+      this.cacheExpiry = null;
+      throw new InternalServerErrorException('대시보드 통계 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 변화율 계산 (백분율)
+   * @param oldValue 이전 값
+   * @param newValue 현재 값
+   * @returns 변화율 (%)
+   */
+  private calculateChangeRate(oldValue: number, newValue: number): number {
+    if (oldValue === 0) {
+      return newValue > 0 ? 100 : 0;
+    }
+
+    const change = ((newValue - oldValue) / oldValue) * 100;
+    return Math.round(change * 10) / 10; // 소수점 1자리
+  }
+
+  /**
+   * 시스템 상태 판단
+   * @param stats 통계 데이터
+   * @returns 시스템 상태
+   */
+  private determineSystemStatus(stats: {
+    totalUsers: number;
+    activeSessions: number;
+    todaySignups: number;
+  }): SystemStatus {
+    // 간단한 휴리스틱:
+    // - 활성 세션이 전체 사용자의 5% 미만이면 warning
+    // - 활성 세션이 전체 사용자의 2% 미만이면 error
+    if (stats.totalUsers > 0) {
+      const activeRate = (stats.activeSessions / stats.totalUsers) * 100;
+
+      if (activeRate < 2) {
+        return 'error';
+      } else if (activeRate < 5) {
+        return 'warning';
+      }
+    }
+
+    return 'healthy';
+  }
+
+  /**
+   * 서버 상태 목록 조회
+   * GET /api/admin/dashboard/servers
+   */
+  async getServers(): Promise<ServerStatusDto[]> {
+    this.logger.debug('getServers');
+
+    try {
+      const now = new Date();
+
+      // API Server 메트릭
+      const apiCpu = this.getStableMetric(35, 10);
+      const apiMemory = this.getStableMetric(60, 8);
+
+      // Database 메트릭
+      const dbCpu = this.getStableMetric(28, 8);
+      const dbMemory = this.getStableMetric(68, 10);
+
+      const servers: ServerStatusDto[] = [
+        // 1. Main API Server
+        new ServerStatusDto({
+          name: 'Main API Server',
+          status: this.determineServerStatus(apiCpu, apiMemory),
+          responseTime: this.getStableMetric(45, 15),
+          cpu: apiCpu,
+          memory: apiMemory,
+          connections: await this.getActiveConnections(),
+          lastCheck: now.toISOString(),
+        }),
+
+        // 2. Database (Primary)
+        new ServerStatusDto({
+          name: 'Database (Primary)',
+          status: this.determineServerStatus(dbCpu, dbMemory),
+          responseTime: this.getStableMetric(12, 5),
+          cpu: dbCpu,
+          memory: dbMemory,
+          storage: await this.getStorageUsage(),
+          lastCheck: now.toISOString(),
+        }),
+
+        // 3. Redis Cache
+        new ServerStatusDto({
+          name: 'Redis Cache',
+          status: 'healthy',
+          responseTime: this.getStableMetric(2, 1),
+          cpu: this.getStableMetric(12, 5),
+          memory: this.getStableMetric(38, 8),
+          lastCheck: now.toISOString(),
+        }),
+
+        // 4. Storage (S3/MinIO)
+        new ServerStatusDto({
+          name: 'Object Storage',
+          status: 'healthy',
+          responseTime: this.getStableMetric(28, 12),
+          cpu: this.getStableMetric(18, 6),
+          memory: this.getStableMetric(45, 10),
+          storage: await this.getStorageUsage(),
+          lastCheck: now.toISOString(),
+        }),
+      ];
+
+      return servers;
+    } catch (error) {
+      this.logger.error('Failed to get server status', error);
+      throw new InternalServerErrorException('서버 상태 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 활성 연결 수 (실제 RefreshToken 기반)
+   */
+  private async getActiveConnections(): Promise<number> {
+    try {
+      const oneDayAgo = new Date();
+      oneDayAgo.setDate(oneDayAgo.getDate() - 1);
+
+      const count = await this.prisma.refreshToken.count({
+        where: {
+          createdAt: { gte: oneDayAgo },
+          expiresAt: { gte: new Date() },
+          revokedAt: null,
+        },
+      });
+
+      return count;
+    } catch (error) {
+      this.logger.warn('Failed to get active connections, returning 0', error);
+      return 0;  // Fallback
+    }
+  }
+
+  /**
+   * 스토리지 사용률 계산
+   * 실제 Upload 테이블 기반
+   */
+  private async getStorageUsage(): Promise<number> {
+    try {
+      const totalUploads = await this.prisma.upload.count();
+      // 간단한 추정: 업로드 수를 기반으로 계산
+      // 실제로는 Bucket API에서 실제 사용량 조회
+      const estimatedUsage = Math.min((totalUploads / 10000) * 100, 90);
+      return Math.round(estimatedUsage);
+    } catch {
+      return 45; // fallback
+    }
+  }
+
+  /**
+   * 시간 기반 안정적 메트릭 생성
+   * 랜덤 대신 시간에 따라 부드럽게 변동
+   * @param base 기본값
+   * @param variance 변동폭
+   * @returns 계산된 메트릭 값
+   */
+  private getStableMetric(base: number, variance: number): number {
+    const now = new Date();
+    const minute = now.getMinutes();
+    const second = now.getSeconds();
+    
+    // 10분 주기로 부드럽게 변동 (sin 곡선)
+    const totalSeconds = minute * 60 + second;
+    const cycleOffset = Math.sin((totalSeconds / 600) * Math.PI) * variance;
+    
+    return Math.round(base + cycleOffset);
+  }
+
+  /**
+   * 서버 상태 판단
+   * CPU와 Memory 메트릭 기반
+   * @param cpu CPU 사용률 (%)
+   * @param memory Memory 사용률 (%)
+   * @returns 서버 상태
+   */
+  private determineServerStatus(cpu: number, memory: number): SystemStatus {
+    if (cpu > 80 || memory > 85) {
+      return 'error';
+    } else if (cpu > 65 || memory > 75) {
+      return 'warning';
+    }
+    return 'healthy';
+  }
+}
+

--- a/backend/src/modules/admin/dto/admin-user-response.dto.ts
+++ b/backend/src/modules/admin/dto/admin-user-response.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString, IsArray, IsEnum } from 'class-validator';
+import { getPermissionsByRole, UserRole } from '../constants';
+
+/**
+ * Admin User Response DTO
+ * 관리자 API에서 사용자 정보를 반환할 때 사용
+ */
+export class AdminUserResponseDto {
+  @ApiProperty({
+    description: '사용자 ID',
+    example: 'user-123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty({
+    description: '사용자 이메일',
+    example: 'admin@example.com',
+  })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    description: '사용자 이름',
+    example: '관리자',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({
+    description: '사용자 역할',
+    enum: UserRole,
+    example: UserRole.ADMIN,
+  })
+  @IsEnum(UserRole)
+  role: string;
+
+  @ApiProperty({
+    description: '사용자 권한 목록',
+    example: ['user:read', 'user:write', 'plan:read'],
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  permissions: string[];
+
+  constructor(data: {
+    id: string;
+    email: string;
+    displayName: string;
+    role: string;
+  }) {
+    this.id = data.id;
+    this.email = data.email;
+    this.name = data.displayName;
+    this.role = data.role;
+    this.permissions = getPermissionsByRole(data.role);
+  }
+}

--- a/backend/src/modules/admin/dto/dashboard-stats-response.dto.ts
+++ b/backend/src/modules/admin/dto/dashboard-stats-response.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 시스템 상태
+ */
+export type SystemStatus = 'healthy' | 'warning' | 'error';
+
+/**
+ * 대시보드 통계 응답 DTO
+ * GET /api/admin/dashboard/stats
+ */
+export class DashboardStatsResponseDto {
+  @ApiProperty({
+    description: '전체 사용자 수',
+    example: 17948,
+  })
+  totalUsers!: number;
+
+  @ApiProperty({
+    description: '전체 사용자 수 변화율 (%)',
+    example: 12.5,
+  })
+  totalUsersChange!: number;
+
+  @ApiProperty({
+    description: '활성 세션 수',
+    example: 1247,
+  })
+  activeSessions!: number;
+
+  @ApiProperty({
+    description: '활성 세션 수 변화율 (%)',
+    example: 8.3,
+  })
+  activeSessionsChange!: number;
+
+  @ApiProperty({
+    description: '오늘 가입자 수',
+    example: 156,
+  })
+  todaySignups!: number;
+
+  @ApiProperty({
+    description: '오늘 가입자 수 변화율 (%)',
+    example: -2.1,
+  })
+  todaySignupsChange!: number;
+
+  @ApiProperty({
+    description: '시스템 상태',
+    enum: ['healthy', 'warning', 'error'],
+    example: 'healthy',
+  })
+  systemStatus!: SystemStatus;
+
+  constructor(partial: Partial<DashboardStatsResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/index.ts
+++ b/backend/src/modules/admin/dto/index.ts
@@ -1,0 +1,13 @@
+export * from './admin-user-response.dto';
+export * from './dashboard-stats-response.dto';
+export * from './server-status.dto';
+export * from './user-list.dto';
+export * from './user-detail.dto';
+export * from './update-user-role.dto';
+export * from './user-status.dto';
+export * from './plans.dto';
+export * from './subscriptions.dto';
+export * from './plan-distribution.dto';
+export * from './monitoring.dto';
+export * from './settings.dto';
+

--- a/backend/src/modules/admin/dto/monitoring.dto.ts
+++ b/backend/src/modules/admin/dto/monitoring.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsIn } from 'class-validator';
+
+/**
+ * 6.2 서버 메트릭 Query
+ */
+export class ServerMetricsQueryDto {
+  @ApiProperty({ description: '기간', enum: ['1h', '24h', '7d'], required: false })
+  @IsOptional()
+  @IsString()
+  @IsIn(['1h', '24h', '7d'])
+  period?: string;
+}
+
+/**
+ * 6.2 서버 메트릭 항목
+ */
+export class MetricPointDto {
+  @ApiProperty({ description: '타임스탬프', example: '2024-12-01T10:00:00Z' })
+  timestamp!: string;
+
+  @ApiProperty({ description: 'CPU 사용률 (%)', example: 32 })
+  cpu!: number;
+
+  @ApiProperty({ description: '메모리 사용률 (%)', example: 60 })
+  memory!: number;
+
+  @ApiProperty({ description: '응답 시간 (ms)', example: 43 })
+  responseTime!: number;
+}
+
+/**
+ * 6.2 서버 메트릭 응답
+ */
+export class ServerMetricsDto {
+  @ApiProperty({ description: '서버 이름', example: 'Main API Server' })
+  server!: string;
+
+  @ApiProperty({ description: '메트릭 데이터', type: [MetricPointDto] })
+  metrics!: MetricPointDto[];
+
+  constructor(partial: Partial<ServerMetricsDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/plan-distribution.dto.ts
+++ b/backend/src/modules/admin/dto/plan-distribution.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 5.6 요금제 분포 항목
+ */
+export class PlanDistributionDto {
+  @ApiProperty({ description: '요금제 ID', example: 'plan-free' })
+  planId!: string;
+
+  @ApiProperty({ description: '요금제 이름', example: '무료 플랜' })
+  planName!: string;
+
+  @ApiProperty({ description: '사용자 수', example: 12847 })
+  userCount!: number;
+
+  @ApiProperty({ description: '비율 (%)', example: 71.6 })
+  percentage!: number;
+}
+

--- a/backend/src/modules/admin/dto/plans.dto.ts
+++ b/backend/src/modules/admin/dto/plans.dto.ts
@@ -1,0 +1,187 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsNumber, IsOptional, IsIn, IsArray, ValidateNested, IsBoolean, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * 요금제 기능
+ */
+export class PlanFeatureDto {
+  @ApiProperty({ description: '기능 키', example: 'notes' })
+  @IsString()
+  key!: string;
+
+  @ApiProperty({ description: '기능 이름', example: '노트 생성' })
+  @IsString()
+  name!: string;
+
+  @ApiProperty({ description: '활성화 여부', example: true })
+  @IsBoolean()
+  enabled!: boolean;
+
+  @ApiProperty({ description: '제한 값', example: 10, required: false })
+  @IsOptional()
+  @IsNumber()
+  limit?: number | null;
+
+  @ApiProperty({ description: '단위', example: '개', required: false })
+  @IsOptional()
+  @IsString()
+  unit?: string | null;
+}
+
+/**
+ * 요금제 목록 항목
+ */
+export class PlanDto {
+  @ApiProperty({ description: '요금제 ID', example: 'plan-free' })
+  id!: string;
+
+  @ApiProperty({ description: '요금제 이름', example: '무료 플랜' })
+  name!: string;
+
+  @ApiProperty({ description: '요금제 설명', example: '제한된 기능으로...' })
+  description!: string;
+
+  @ApiProperty({ description: '월간 가격 (원)', example: 0 })
+  monthlyPrice!: number;
+
+  @ApiProperty({ description: '연간 가격 (원)', example: 0 })
+  yearlyPrice!: number;
+
+  @ApiProperty({ description: '상태', enum: ['active', 'inactive', 'deprecated'], example: 'active' })
+  status!: string;
+
+  @ApiProperty({ description: '기능 목록', type: [PlanFeatureDto] })
+  features!: PlanFeatureDto[];
+
+  @ApiProperty({ description: '구독자 수', example: 12847 })
+  subscriberCount!: number;
+
+  @ApiProperty({ description: '생성일', example: '2024-01-01T00:00:00Z' })
+  createdAt!: string;
+
+  @ApiProperty({ description: '수정일', example: '2024-11-15T10:00:00Z' })
+  updatedAt!: string;
+
+  constructor(partial: Partial<PlanDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 요금제 생성 요청
+ */
+export class CreatePlanDto {
+  @ApiProperty({ description: '요금제 이름', example: 'Enterprise' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({ description: '요금제 설명', example: '기업용 플랜' })
+  @IsString()
+  @IsNotEmpty()
+  description!: string;
+
+  @ApiProperty({ description: '월간 가격 (원)', example: 50000 })
+  @IsNumber()
+  @Min(0, { message: '가격은 0 이상이어야 합니다' })
+  monthlyPrice!: number;
+
+  @ApiProperty({ description: '연간 가격 (원)', example: 500000 })
+  @IsNumber()
+  @Min(0, { message: '가격은 0 이상이어야 합니다' })
+  yearlyPrice!: number;
+
+  @ApiProperty({ description: '상태', enum: ['active', 'inactive'], example: 'active' })
+  @IsString()
+  @IsIn(['active', 'inactive'])
+  status!: string;
+
+  @ApiProperty({ description: '기능 목록', type: [PlanFeatureDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PlanFeatureDto)
+  features!: PlanFeatureDto[];
+}
+
+/**
+ * 요금제 수정 요청
+ */
+export class UpdatePlanDto {
+  @ApiProperty({ description: '요금제 이름', required: false })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiProperty({ description: '요금제 설명', required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: '월간 가격 (원)', required: false })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  monthlyPrice?: number;
+
+  @ApiProperty({ description: '연간 가격 (원)', required: false })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  yearlyPrice?: number;
+
+  @ApiProperty({ description: '상태', required: false })
+  @IsOptional()
+  @IsString()
+  @IsIn(['active', 'inactive', 'deprecated'])
+  status?: string;
+
+  @ApiProperty({ description: '기능 목록', type: [PlanFeatureDto], required: false })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PlanFeatureDto)
+  features?: PlanFeatureDto[];
+}
+
+/**
+ * 요금제 변경 이력 항목
+ */
+export class PlanChangeDto {
+  @ApiProperty({ description: '변경된 필드', example: 'monthlyPrice' })
+  field!: string;
+
+  @ApiProperty({ description: '이전 값', example: 4500 })
+  oldValue!: any;
+
+  @ApiProperty({ description: '새 값', example: 5000 })
+  newValue!: any;
+}
+
+/**
+ * 요금제 변경 이력
+ */
+export class PlanHistoryDto {
+  @ApiProperty({ description: '이력 ID', example: 'history-001' })
+  id!: string;
+
+  @ApiProperty({ description: '요금제 ID', example: 'plan-student-pro' })
+  planId!: string;
+
+  @ApiProperty({ description: '변경한 사용자 ID', example: 'user-001' })
+  changedBy!: string;
+
+  @ApiProperty({ description: '변경한 사용자 이름', example: '관리자' })
+  changedByName!: string;
+
+  @ApiProperty({ description: '변경 내역', type: [PlanChangeDto] })
+  changes!: PlanChangeDto[];
+
+  @ApiProperty({ description: '변경일', example: '2024-11-01T09:00:00Z' })
+  createdAt!: string;
+
+  constructor(partial: Partial<PlanHistoryDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/server-status.dto.ts
+++ b/backend/src/modules/admin/dto/server-status.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SystemStatus } from './dashboard-stats-response.dto';
+
+/**
+ * 서버 상태 응답 DTO
+ * GET /api/admin/dashboard/servers
+ */
+export class ServerStatusDto {
+  @ApiProperty({
+    description: '서버 이름',
+    example: 'Main API Server',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: '서버 상태',
+    enum: ['healthy', 'warning', 'error'],
+    example: 'healthy',
+  })
+  status!: SystemStatus;
+
+  @ApiProperty({
+    description: '응답 시간 (ms)',
+    example: 45,
+  })
+  responseTime!: number;
+
+  @ApiProperty({
+    description: 'CPU 사용률 (%)',
+    example: 35,
+  })
+  cpu!: number;
+
+  @ApiProperty({
+    description: '메모리 사용률 (%)',
+    example: 62,
+  })
+  memory!: number;
+
+  @ApiProperty({
+    description: '연결 수 (API 서버의 경우)',
+    example: 1247,
+    required: false,
+  })
+  connections?: number;
+
+  @ApiProperty({
+    description: '스토리지 사용률 (%, 데이터베이스의 경우)',
+    example: 45,
+    required: false,
+  })
+  storage?: number;
+
+  @ApiProperty({
+    description: '마지막 체크 시간',
+    example: '2024-12-01T10:30:00Z',
+  })
+  lastCheck!: string;
+
+  constructor(partial: Partial<ServerStatusDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/settings.dto.ts
+++ b/backend/src/modules/admin/dto/settings.dto.ts
@@ -1,0 +1,120 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, Min, Max, IsOptional, ValidateNested, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * 7.1 일반 설정
+ */
+export class GeneralSettingsDto {
+  @ApiProperty({ description: '유지보수 모드', example: false })
+  @IsBoolean()
+  maintenanceMode!: boolean;
+
+  @ApiProperty({ description: '최대 업로드 크기 (MB)', example: 100 })
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  maxUploadSize!: number;
+
+  @ApiProperty({ description: '세션 타임아웃 (분)', example: 60 })
+  @IsInt()
+  @Min(5)
+  @Max(1440)
+  sessionTimeout!: number;
+}
+
+/**
+ * 7.1 보안 설정
+ */
+export class SecuritySettingsDto {
+  @ApiProperty({ description: '이메일 인증 필수', example: true })
+  @IsBoolean()
+  requireEmailVerification!: boolean;
+
+  @ApiProperty({ description: '최대 로그인 시도 횟수', example: 5 })
+  @IsInt()
+  @Min(3)
+  @Max(10)
+  maxLoginAttempts!: number;
+
+  @ApiProperty({ description: '계정 잠금 시간 (분)', example: 30 })
+  @IsInt()
+  @Min(5)
+  @Max(1440)
+  lockoutDuration!: number;
+}
+
+/**
+ * 7.1 환경 설정 (읽기 전용)
+ */
+export class EnvironmentSettingsDto {
+  @ApiProperty({ description: '버전', example: '1.0.0' })
+  version!: string;
+
+  @ApiProperty({ description: '환경', example: 'development' })
+  environment!: string;
+
+  @ApiProperty({ description: 'API URL', example: 'http://localhost:4000' })
+  apiUrl!: string;
+
+  @ApiProperty({ description: 'Mock 모드', example: true })
+  mockMode!: boolean;
+}
+
+/**
+ * 7.1 시스템 설정 조회 응답
+ */
+export class SystemSettingsDto {
+  @ApiProperty({ description: '일반 설정', type: GeneralSettingsDto })
+  @ValidateNested()
+  @Type(() => GeneralSettingsDto)
+  general!: GeneralSettingsDto;
+
+  @ApiProperty({ description: '보안 설정', type: SecuritySettingsDto })
+  @ValidateNested()
+  @Type(() => SecuritySettingsDto)
+  security!: SecuritySettingsDto;
+
+  @ApiProperty({ description: '환경 설정', type: EnvironmentSettingsDto })
+  environment!: EnvironmentSettingsDto;
+
+  constructor(partial: Partial<SystemSettingsDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 7.2 시스템 설정 저장 요청
+ */
+export class UpdateSystemSettingsDto {
+  @ApiProperty({ description: '일반 설정', type: GeneralSettingsDto, required: false })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GeneralSettingsDto)
+  general?: GeneralSettingsDto;
+
+  @ApiProperty({ description: '보안 설정', type: SecuritySettingsDto, required: false })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SecuritySettingsDto)
+  security?: SecuritySettingsDto;
+}
+
+/**
+ * 7.2 시스템 설정 저장 응답
+ */
+export class UpdateSystemSettingsResponseDto {
+  @ApiProperty({ description: '성공 여부', example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: '메시지', example: '설정이 저장되었습니다.' })
+  message!: string;
+
+  @ApiProperty({ description: '업데이트된 설정', type: SystemSettingsDto })
+  data!: SystemSettingsDto;
+
+  constructor(partial: Partial<UpdateSystemSettingsResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/subscriptions.dto.ts
+++ b/backend/src/modules/admin/dto/subscriptions.dto.ts
@@ -1,0 +1,268 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsIn, IsInt, Min, IsDateString, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * 5.1 구독 통계 Query
+ */
+export class SubscriptionStatsQueryDto {
+  @ApiProperty({ description: '기간', enum: ['1m', '3m', '6m', '1y'], required: false })
+  @IsOptional()
+  @IsString()
+  @IsIn(['1m', '3m', '6m', '1y'])
+  period?: string;
+}
+
+/**
+ * 5.1 구독 통계 응답
+ */
+export class SubscriptionStatsDto {
+  @ApiProperty({ description: '총 수익 (원)', example: 156789000 })
+  totalRevenue!: number;
+
+  @ApiProperty({ description: '총 수익 변화율 (%)', example: 15.3 })
+  totalRevenueChange!: number;
+
+  @ApiProperty({ description: '구독자 수', example: 6818 })
+  subscriberCount!: number;
+
+  @ApiProperty({ description: '구독자 수 변화율 (%)', example: 8.2 })
+  subscriberCountChange!: number;
+
+  @ApiProperty({ description: 'MRR (월간 반복 수익)', example: 34220000 })
+  mrr!: number;
+
+  @ApiProperty({ description: 'MRR 변화율 (%)', example: 12.1 })
+  mrrChange!: number;
+
+  @ApiProperty({ description: '이탈률 (%)', example: 3.6 })
+  churnRate!: number;
+
+  @ApiProperty({ description: '이탈률 변화 (%p)', example: -0.5 })
+  churnRateChange!: number;
+
+  @ApiProperty({ description: '평균 사용자당 수익 (ARPU)', example: 5020 })
+  arpu!: number;
+
+  @ApiProperty({ description: '고객 생애 가치 (LTV)', example: 125500 })
+  ltv!: number;
+
+  constructor(partial: Partial<SubscriptionStatsDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 5.2 수익 추이 Query
+ */
+export class RevenueQueryDto {
+  @ApiProperty({ description: '시작일', required: false })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiProperty({ description: '종료일', required: false })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiProperty({ description: '단위', enum: ['daily', 'weekly', 'monthly'], required: false })
+  @IsOptional()
+  @IsString()
+  @IsIn(['daily', 'weekly', 'monthly'])
+  granularity?: string;
+}
+
+/**
+ * 5.2 수익 추이 항목
+ */
+export class RevenueItemDto {
+  @ApiProperty({ description: '날짜', example: '2024-06' })
+  date!: string;
+
+  @ApiProperty({ description: '수익 (원)', example: 28500000 })
+  revenue!: number;
+
+  @ApiProperty({ description: '구독 수', example: 5420 })
+  subscriptions!: number;
+
+  @ApiProperty({ description: '신규 구독', example: 420 })
+  newSubscriptions!: number;
+
+  @ApiProperty({ description: '갱신', example: 4800 })
+  renewals!: number;
+
+  @ApiProperty({ description: '취소', example: 180 })
+  cancellations!: number;
+}
+
+/**
+ * 5.3 요금제별 분석 항목
+ */
+export class SubscriptionByPlanDto {
+  @ApiProperty({ description: '요금제 ID', example: 'plan-student-pro' })
+  planId!: string;
+
+  @ApiProperty({ description: '요금제 이름', example: 'Student Pro' })
+  planName!: string;
+
+  @ApiProperty({ description: '구독자 수', example: 3856 })
+  subscribers!: number;
+
+  @ApiProperty({ description: '수익 (원)', example: 19280000 })
+  revenue!: number;
+
+  @ApiProperty({ description: '변화율 (%)', example: 12.5 })
+  change!: number;
+
+  @ApiProperty({ description: '비율 (%)', example: 75.6 })
+  percentage!: number;
+
+  @ApiProperty({ description: '평균 구독 기간 (일)', example: 195 })
+  avgSubscriptionLengthDays!: number;
+}
+
+/**
+ * 5.4 이탈 분석 - 이유별
+ */
+export class ChurnReasonDto {
+  @ApiProperty({ description: '이유 코드', example: 'price' })
+  reason!: string;
+
+  @ApiProperty({ description: '이유 라벨', example: '가격' })
+  label!: string;
+
+  @ApiProperty({ description: '건수', example: 65 })
+  count!: number;
+
+  @ApiProperty({ description: '비율 (%)', example: 35.1 })
+  percentage!: number;
+}
+
+/**
+ * 5.4 이탈 분석 - 요금제별
+ */
+export class ChurnByPlanDto {
+  @ApiProperty({ description: '요금제 ID', example: 'plan-student-pro' })
+  planId!: string;
+
+  @ApiProperty({ description: '요금제 이름', example: 'Student Pro' })
+  planName!: string;
+
+  @ApiProperty({ description: '이탈 건수', example: 142 })
+  churned!: number;
+
+  @ApiProperty({ description: '이탈률 (%)', example: 3.7 })
+  churnRate!: number;
+}
+
+/**
+ * 5.4 이탈 분석 응답
+ */
+export class ChurnAnalysisDto {
+  @ApiProperty({ description: '총 이탈 건수', example: 185 })
+  totalChurned!: number;
+
+  @ApiProperty({ description: '이탈률 (%)', example: 3.6 })
+  churnRate!: number;
+
+  @ApiProperty({ description: '손실 수익 (원)', example: 1250000 })
+  revenueLost!: number;
+
+  @ApiProperty({ description: '이유별 분석', type: [ChurnReasonDto] })
+  reasons!: ChurnReasonDto[];
+
+  @ApiProperty({ description: '요금제별 분석', type: [ChurnByPlanDto] })
+  byPlan!: ChurnByPlanDto[];
+
+  constructor(partial: Partial<ChurnAnalysisDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 5.5 구독 목록 Query
+ */
+export class SubscriptionListQueryDto {
+  @ApiProperty({ description: '페이지', required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ description: '페이지당 항목 수', required: false, default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+
+  @ApiProperty({ description: '상태 필터', enum: ['active', 'cancelled', 'past_due'], required: false })
+  @IsOptional()
+  @IsString()
+  @IsIn(['active', 'cancelled', 'past_due'])
+  status?: string;
+
+  @ApiProperty({ description: '요금제 필터', required: false })
+  @IsOptional()
+  @IsString()
+  planId?: string;
+}
+
+/**
+ * 5.5 구독 목록 항목
+ */
+export class SubscriptionItemDto {
+  @ApiProperty({ description: '구독 ID', example: 'sub-001' })
+  id!: string;
+
+  @ApiProperty({ description: '사용자 ID', example: 'user-003' })
+  userId!: string;
+
+  @ApiProperty({ description: '사용자 이름', example: '김선생' })
+  userName!: string;
+
+  @ApiProperty({ description: '사용자 이메일', example: 'kim@example.com' })
+  userEmail!: string;
+
+  @ApiProperty({ description: '요금제 ID', example: 'plan-educator-pro' })
+  planId!: string;
+
+  @ApiProperty({ description: '요금제 이름', example: 'Educator Pro' })
+  planName!: string;
+
+  @ApiProperty({ description: '상태', example: 'active' })
+  status!: string;
+
+  @ApiProperty({ description: '금액 (원)', example: 12000 })
+  amount!: number;
+
+  @ApiProperty({ description: '결제 주기', example: 'monthly' })
+  billingCycle!: string;
+
+  @ApiProperty({ description: '현재 기간 시작', example: '2024-11-01T00:00:00Z' })
+  currentPeriodStart!: string;
+
+  @ApiProperty({ description: '현재 기간 종료', example: '2024-12-01T00:00:00Z' })
+  currentPeriodEnd!: string;
+
+  @ApiProperty({ description: '생성일', example: '2024-01-01T00:00:00Z' })
+  createdAt!: string;
+}
+
+/**
+ * 5.6 구독 취소 요청
+ */
+export class CancelSubscriptionDto {
+  @ApiProperty({ description: '취소 사유', example: 'price' })
+  @IsString()
+  @IsNotEmpty()
+  reason!: string;
+
+  @ApiProperty({ description: '사유 상세', required: false })
+  @IsOptional()
+  @IsString()
+  reasonDetail?: string;
+}
+

--- a/backend/src/modules/admin/dto/update-user-role.dto.ts
+++ b/backend/src/modules/admin/dto/update-user-role.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsIn } from 'class-validator';
+
+/**
+ * 사용자 역할 변경 요청 DTO
+ */
+export class UpdateUserRoleDto {
+  @ApiProperty({
+    description: '변경할 역할',
+    enum: ['admin', 'operator', 'user'],
+    example: 'operator',
+  })
+  @IsString()
+  @IsIn(['admin', 'operator', 'user'])
+  role!: string;
+}
+
+/**
+ * 사용자 역할 변경 응답 DTO
+ */
+export class UpdateUserRoleResponseDto {
+  @ApiProperty({ description: '사용자 ID', example: 'user-001' })
+  id!: string;
+
+  @ApiProperty({ description: '변경된 역할', example: 'operator' })
+  role!: string;
+
+  constructor(partial: Partial<UpdateUserRoleResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/user-detail.dto.ts
+++ b/backend/src/modules/admin/dto/user-detail.dto.ts
@@ -1,0 +1,102 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 사용자 통계 정보
+ */
+export class UserStatsDto {
+  @ApiProperty({ description: '노트 수', example: 156 })
+  notesCount!: number;
+
+  @ApiProperty({ description: '세션 참여 수', example: 89 })
+  sessionsCount!: number;
+
+  @ApiProperty({ description: '총 사용 시간 (시간)', example: 245.5 })
+  totalUsageHours!: number;
+
+  @ApiProperty({ description: '스토리지 사용량 (MB)', example: 1250 })
+  storageUsedMb!: number;
+
+  constructor(partial: Partial<UserStatsDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 최근 활동
+ */
+export class RecentActivityDto {
+  @ApiProperty({ description: '활동 ID', example: 'act-001' })
+  id!: string;
+
+  @ApiProperty({
+    description: '활동 타입',
+    enum: ['login', 'note_create', 'session_join', 'file_upload'],
+    example: 'login',
+  })
+  type!: string;
+
+  @ApiProperty({ description: '활동 설명', example: '로그인' })
+  description!: string;
+
+  @ApiProperty({ description: '생성일', example: '2024-12-01T09:30:00Z' })
+  createdAt!: string;
+
+  @ApiProperty({ description: '추가 메타데이터', example: {} })
+  metadata!: Record<string, any>;
+
+  constructor(partial: Partial<RecentActivityDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 사용자 상세 정보
+ */
+export class UserDetailDto {
+  @ApiProperty({ description: '사용자 ID', example: 'user-001' })
+  id!: string;
+
+  @ApiProperty({ description: '이메일', example: 'user@example.com' })
+  email!: string;
+
+  @ApiProperty({ description: '이름', example: '홍길동' })
+  name!: string;
+
+  @ApiProperty({ description: '프로필 사진 URL', required: false })
+  picture?: string;
+
+  @ApiProperty({ description: '역할', example: 'user' })
+  role!: string;
+
+  @ApiProperty({ description: '상태', example: 'active' })
+  status!: string;
+
+  @ApiProperty({ description: '가입일', example: '2024-01-15T10:00:00Z' })
+  createdAt!: string;
+
+  @ApiProperty({ description: '마지막 로그인', required: false })
+  lastLoginAt?: string;
+
+  @ApiProperty({ description: '사용자 통계', type: UserStatsDto })
+  stats!: UserStatsDto;
+
+  @ApiProperty({ description: '최근 활동 목록', type: [RecentActivityDto] })
+  recentActivities!: RecentActivityDto[];
+
+  constructor(partial: Partial<UserDetailDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 사용자 상세 응답
+ */
+export class UserDetailResponseDto {
+  @ApiProperty({ description: '사용자 상세 정보', type: UserDetailDto })
+  data!: UserDetailDto;
+
+  constructor(partial: Partial<UserDetailResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/user-list.dto.ts
+++ b/backend/src/modules/admin/dto/user-list.dto.ts
@@ -1,0 +1,176 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsInt, Min, Max, IsString, IsIn } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * 사용자 목록 조회 Query DTO
+ */
+export class UserListQueryDto {
+  @ApiProperty({
+    description: '페이지 번호',
+    example: 1,
+    required: false,
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({
+    description: '페이지당 항목 수',
+    example: 20,
+    required: false,
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiProperty({
+    description: '역할 필터',
+    enum: ['admin', 'operator', 'user'],
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['admin', 'operator', 'user'])
+  role?: string;
+
+  @ApiProperty({
+    description: '상태 필터',
+    enum: ['active', 'inactive', 'suspended', 'banned'],
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['active', 'inactive', 'suspended', 'banned'])
+  status?: string;
+
+  @ApiProperty({
+    description: '이름/이메일 검색',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({
+    description: '정렬 기준',
+    enum: ['createdAt', 'lastLoginAt', 'name'],
+    required: false,
+    default: 'createdAt',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['createdAt', 'lastLoginAt', 'name'])
+  sortBy?: string = 'createdAt';
+
+  @ApiProperty({
+    description: '정렬 방향',
+    enum: ['asc', 'desc'],
+    required: false,
+    default: 'desc',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: string = 'desc';
+}
+
+/**
+ * 페이지네이션 정보
+ */
+export class PaginationDto {
+  @ApiProperty({ description: '현재 페이지', example: 1 })
+  page!: number;
+
+  @ApiProperty({ description: '페이지당 항목 수', example: 20 })
+  pageSize!: number;
+
+  @ApiProperty({ description: '전체 항목 수', example: 17948 })
+  total!: number;
+
+  @ApiProperty({ description: '전체 페이지 수', example: 898 })
+  totalPages!: number;
+
+  constructor(partial: Partial<PaginationDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 구독 정보 (간략)
+ */
+export class UserSubscriptionDto {
+  @ApiProperty({ description: '플랜 ID', required: false })
+  planId?: string;
+
+  @ApiProperty({ description: '플랜 이름', required: false })
+  planName?: string;
+
+  @ApiProperty({ description: '구독 상태', required: false })
+  status?: string;
+}
+
+/**
+ * 사용자 목록 항목
+ */
+export class UserListItemDto {
+  @ApiProperty({ description: '사용자 ID', example: 'user-001' })
+  id!: string;
+
+  @ApiProperty({ description: '이메일', example: 'user@example.com' })
+  email!: string;
+
+  @ApiProperty({ description: '이름', example: '홍길동' })
+  name!: string;
+
+  @ApiProperty({ description: '프로필 사진 URL', required: false })
+  picture?: string;
+
+  @ApiProperty({ description: '역할', example: 'user' })
+  role!: string;
+
+  @ApiProperty({ description: '상태', example: 'active' })
+  status!: string;
+
+  @ApiProperty({ description: '가입일', example: '2024-01-15T10:00:00Z' })
+  createdAt!: string;
+
+  @ApiProperty({ description: '마지막 로그인', required: false })
+  lastLoginAt?: string;
+
+  @ApiProperty({ description: '정지 종료일', required: false })
+  suspendedUntil?: string | null;
+
+  @ApiProperty({ description: '차단 사유', required: false })
+  banReason?: string | null;
+
+  @ApiProperty({ description: '구독 정보', type: UserSubscriptionDto, required: false })
+  subscription?: UserSubscriptionDto;
+
+  constructor(partial: Partial<UserListItemDto>) {
+    Object.assign(this, partial);
+  }
+}
+
+/**
+ * 사용자 목록 응답
+ */
+export class UserListResponseDto {
+  @ApiProperty({ description: '사용자 목록', type: [UserListItemDto] })
+  data!: UserListItemDto[];
+
+  @ApiProperty({ description: '페이지네이션 정보', type: PaginationDto })
+  pagination!: PaginationDto;
+
+  constructor(partial: Partial<UserListResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/dto/user-status.dto.ts
+++ b/backend/src/modules/admin/dto/user-status.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsDateString } from 'class-validator';
+
+/**
+ * 사용자 일시 정지 요청 DTO
+ * POST /api/admin/users/:userId/suspend
+ */
+export class SuspendUserDto {
+  @ApiProperty({
+    description: '정지 사유',
+    example: '이용약관 위반',
+  })
+  @IsString()
+  @IsNotEmpty()
+  reason!: string;
+
+  @ApiProperty({
+    description: '정지 종료일 (ISO 8601)',
+    example: '2024-12-15T00:00:00Z',
+  })
+  @IsDateString()
+  suspendUntil!: string;
+}
+
+/**
+ * 사용자 영구 차단 요청 DTO
+ * POST /api/admin/users/:userId/ban
+ */
+export class BanUserDto {
+  @ApiProperty({
+    description: '차단 사유',
+    example: '반복적인 이용약관 위반',
+  })
+  @IsString()
+  @IsNotEmpty()
+  reason!: string;
+}
+
+/**
+ * 사용자 상태 변경 응답 DTO
+ */
+export class UserStatusResponseDto {
+  @ApiProperty({ description: '사용자 ID', example: 'user-001' })
+  id!: string;
+
+  @ApiProperty({ description: '상태', example: 'suspended' })
+  status!: string;
+
+  @ApiProperty({ description: '정지 종료일', required: false })
+  suspendedUntil?: string | null;
+
+  @ApiProperty({ description: '차단 사유', required: false })
+  banReason?: string | null;
+
+  constructor(partial: Partial<UserStatusResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+

--- a/backend/src/modules/admin/guards/admin-only.guard.spec.ts
+++ b/backend/src/modules/admin/guards/admin-only.guard.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { AdminOnlyGuard } from './admin-only.guard';
+import { AdminErrors } from '../constants';
+import { PrismaService } from '../../db/prisma.service';
+
+describe('AdminOnlyGuard', () => {
+  let guard: AdminOnlyGuard;
+  let prismaService: PrismaService;
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      user: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminOnlyGuard,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    guard = module.get<AdminOnlyGuard>(AdminOnlyGuard);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    let context: ExecutionContext;
+    let mockRequest: any;
+
+    beforeEach(() => {
+      mockRequest = {
+        user: null,
+      };
+
+      context = {
+        switchToHttp: () => ({
+          getRequest: () => mockRequest,
+        }),
+      } as ExecutionContext;
+    });
+
+    it('should throw ForbiddenException when user is not found', async () => {
+      mockRequest.user = null;
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.AUTHENTICATION_REQUIRED.message,
+      );
+    });
+
+    it('should throw ForbiddenException when user role is "user"', async () => {
+      mockRequest.user = { id: 'user-001', role: 'user' };
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.ADMIN_ONLY_REQUIRED.message,
+      );
+    });
+
+    it('should throw ForbiddenException when user role is "operator"', async () => {
+      mockRequest.user = { id: 'operator-001', role: 'operator' };
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.ADMIN_ONLY_REQUIRED.message,
+      );
+    });
+
+    it('should allow access ONLY when user role is "admin"', async () => {
+      mockRequest.user = { id: 'admin-001', role: 'admin' };
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it('should load role from database when user has no role', async () => {
+      mockRequest.user = { id: 'user-001' };
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue({
+        role: 'admin',
+      });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(prismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-001' },
+        select: { role: true },
+      });
+      expect(mockRequest.user.role).toBe('admin');
+    });
+
+    it('should throw ForbiddenException when loaded role is not admin', async () => {
+      mockRequest.user = { id: 'user-001' };
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue({
+        role: 'operator',
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.ADMIN_ONLY_REQUIRED.message,
+      );
+    });
+
+    it('should throw ForbiddenException when user not found in database', async () => {
+      mockRequest.user = { id: 'user-001' };
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.AUTHENTICATION_REQUIRED.message,
+      );
+    });
+
+    it('should throw ForbiddenException when user role is empty string', async () => {
+      mockRequest.user = { id: 'user-001', role: '' };
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+    });
+  });
+});
+

--- a/backend/src/modules/admin/guards/admin-only.guard.ts
+++ b/backend/src/modules/admin/guards/admin-only.guard.ts
@@ -1,0 +1,65 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  ForbiddenException,
+} from '@nestjs/common';
+import { isInAdminOnly, RequestUser, AdminErrors } from '../constants';
+import { PrismaService } from '../../db/prisma.service';
+
+/**
+ * Admin Only Guard
+ * admin 역할만 접근 가능 (operator 불가)
+ * 
+ * 사용처:
+ * - 사용자 역할 변경
+ * - 사용자 영구 차단
+ * - 요금제 생성/수정/삭제
+ * - 시스템 설정 변경
+ */
+@Injectable()
+export class AdminOnlyGuard implements CanActivate {
+  private readonly logger = new Logger(AdminOnlyGuard.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as RequestUser | undefined;
+
+    if (!user) {
+      this.logger.warn('AdminOnlyGuard: No user found in request');
+      throw new ForbiddenException(AdminErrors.AUTHENTICATION_REQUIRED.message);
+    }
+
+    // If role is not already loaded, fetch it from database
+    if (!user.role) {
+      const dbUser = await this.prisma.user.findUnique({
+        where: { id: user.id },
+        select: { role: true },
+      });
+
+      if (!dbUser) {
+        this.logger.warn(`AdminOnlyGuard: User not found in database - user=${user.id}`);
+        throw new ForbiddenException(AdminErrors.AUTHENTICATION_REQUIRED.message);
+      }
+
+      // Enrich request user with role
+      user.role = dbUser.role || 'user';
+    }
+
+    const hasAccess = user.role && isInAdminOnly(user.role);
+
+    if (!hasAccess) {
+      this.logger.warn(
+        `AdminOnlyGuard: Access denied - user=${user.id} role=${user.role}`,
+      );
+      throw new ForbiddenException(AdminErrors.ADMIN_ONLY_REQUIRED.message);
+    }
+
+    this.logger.debug(`AdminOnlyGuard: Access granted - user=${user.id}`);
+    return true;
+  }
+}
+

--- a/backend/src/modules/admin/guards/admin-role.guard.spec.ts
+++ b/backend/src/modules/admin/guards/admin-role.guard.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { AdminRoleGuard } from './admin-role.guard';
+import { AdminErrors } from '../constants';
+import { PrismaService } from '../../db/prisma.service';
+
+describe('AdminRoleGuard', () => {
+  let guard: AdminRoleGuard;
+  let prismaService: PrismaService;
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      user: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminRoleGuard,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    guard = module.get<AdminRoleGuard>(AdminRoleGuard);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    let context: ExecutionContext;
+    let mockRequest: any;
+
+    beforeEach(() => {
+      mockRequest = {
+        user: null,
+      };
+
+      context = {
+        switchToHttp: () => ({
+          getRequest: () => mockRequest,
+        }),
+      } as ExecutionContext;
+    });
+
+    it('should throw ForbiddenException when user is not found', async () => {
+      mockRequest.user = null;
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.AUTHENTICATION_REQUIRED.message,
+      );
+    });
+
+    it('should throw ForbiddenException when user role is "user"', async () => {
+      mockRequest.user = { id: 'user-001', role: 'user' };
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.ADMIN_ROLE_REQUIRED.message,
+      );
+    });
+
+    it('should allow access when user role is "admin"', async () => {
+      mockRequest.user = { id: 'admin-001', role: 'admin' };
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it('should allow access when user role is "operator"', async () => {
+      mockRequest.user = { id: 'operator-001', role: 'operator' };
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it('should load role from database when user has no role', async () => {
+      mockRequest.user = { id: 'user-001' };
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue({
+        role: 'admin',
+      });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(prismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-001' },
+        select: { role: true },
+      });
+      expect(mockRequest.user.role).toBe('admin');
+    });
+
+    it('should throw ForbiddenException when user not found in database', async () => {
+      mockRequest.user = { id: 'user-001' };
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        AdminErrors.AUTHENTICATION_REQUIRED.message,
+      );
+    });
+
+    it('should throw ForbiddenException when user role is empty string', async () => {
+      mockRequest.user = { id: 'user-001', role: '' };
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException when user role is unknown', async () => {
+      mockRequest.user = { id: 'user-001', role: 'unknown-role' };
+
+      await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+    });
+  });
+});
+
+

--- a/backend/src/modules/admin/guards/admin-role.guard.ts
+++ b/backend/src/modules/admin/guards/admin-role.guard.ts
@@ -1,0 +1,66 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  ForbiddenException,
+} from '@nestjs/common';
+import { isInAdminRoles, RequestUser, AdminErrors } from '../constants';
+import { PrismaService } from '../../db/prisma.service';
+
+/**
+ * Admin Role Guard
+ * admin 또는 operator 역할을 가진 사용자만 접근 가능
+ * 
+ * 사용처:
+ * - 대시보드 조회
+ * - 사용자 목록 조회
+ * - 요금제 목록 조회
+ * - 구독 통계 조회
+ * - 서버 상태 조회
+ */
+@Injectable()
+export class AdminRoleGuard implements CanActivate {
+  private readonly logger = new Logger(AdminRoleGuard.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as RequestUser | undefined;
+
+    if (!user) {
+      this.logger.warn('AdminRoleGuard: No user found in request');
+      throw new ForbiddenException(AdminErrors.AUTHENTICATION_REQUIRED.message);
+    }
+
+    // If role is not already loaded, fetch it from database
+    if (!user.role) {
+      const dbUser = await this.prisma.user.findUnique({
+        where: { id: user.id },
+        select: { role: true },
+      });
+
+      if (!dbUser) {
+        this.logger.warn(`AdminRoleGuard: User not found in database - user=${user.id}`);
+        throw new ForbiddenException(AdminErrors.AUTHENTICATION_REQUIRED.message);
+      }
+
+      // Enrich request user with role
+      user.role = dbUser.role || 'user';
+    }
+
+    const hasAccess = user.role && isInAdminRoles(user.role);
+
+    if (!hasAccess) {
+      this.logger.warn(
+        `AdminRoleGuard: Access denied - user=${user.id} role=${user.role}`,
+      );
+      throw new ForbiddenException(AdminErrors.ADMIN_ROLE_REQUIRED.message);
+    }
+
+    this.logger.debug(`AdminRoleGuard: Access granted - user=${user.id}`);
+    return true;
+  }
+}
+

--- a/backend/src/modules/admin/guards/index.ts
+++ b/backend/src/modules/admin/guards/index.ts
@@ -1,0 +1,4 @@
+export * from './admin-role.guard';
+export * from './admin-only.guard';
+export * from './permission.guard';
+

--- a/backend/src/modules/admin/guards/permission.guard.ts
+++ b/backend/src/modules/admin/guards/permission.guard.ts
@@ -1,0 +1,78 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  ForbiddenException,
+  SetMetadata,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Permission, hasPermission, RequestUser, AdminErrors } from '../constants';
+
+/**
+ * Permission Metadata Key
+ */
+export const PERMISSIONS_KEY = 'permissions';
+
+/**
+ * Permissions Decorator
+ * 특정 권한이 필요한 엔드포인트에 사용
+ * 
+ * @example
+ * @Permissions(Permission.USER_DELETE)
+ * @UseGuards(JwtAuthGuard, PermissionGuard)
+ * async deleteUser() { ... }
+ */
+export const Permissions = (...permissions: Permission[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);
+
+/**
+ * Permission Guard
+ * 세밀한 권한 체크
+ * 
+ * @Permissions 데코레이터와 함께 사용
+ */
+@Injectable()
+export class PermissionGuard implements CanActivate {
+  private readonly logger = new Logger(PermissionGuard.name);
+
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredPermissions = this.reflector.getAllAndOverride<Permission[]>(
+      PERMISSIONS_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredPermissions || requiredPermissions.length === 0) {
+      // 권한 요구사항이 없으면 통과
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as RequestUser | undefined;
+
+    if (!user || !user.role) {
+      this.logger.warn('PermissionGuard: No user or role found in request');
+      throw new ForbiddenException(AdminErrors.AUTHENTICATION_REQUIRED.message);
+    }
+
+    // 모든 필요한 권한을 가지고 있는지 확인
+    const hasAllPermissions = requiredPermissions.every((permission) =>
+      hasPermission(user.role!, permission),
+    );
+
+    if (!hasAllPermissions) {
+      this.logger.warn(
+        `PermissionGuard: Access denied - user=${user.id} role=${user.role} required=${requiredPermissions.join(',')}`,
+      );
+      throw new ForbiddenException(AdminErrors.INSUFFICIENT_PERMISSIONS.message);
+    }
+
+    this.logger.debug(
+      `PermissionGuard: Access granted - user=${user.id} permissions=${requiredPermissions.join(',')}`,
+    );
+    return true;
+  }
+}
+

--- a/backend/src/modules/admin/monitoring.controller.ts
+++ b/backend/src/modules/admin/monitoring.controller.ts
@@ -1,0 +1,73 @@
+import { Controller, Get, Param, Query, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from './guards';
+import { MonitoringService } from './monitoring.service';
+import { ServerStatusDto, ServerMetricsQueryDto, ServerMetricsDto } from './dto';
+
+/**
+ * Monitoring Controller (Admin)
+ * Base URL: /api/admin/servers
+ * 
+ * 관리자용 서버 모니터링
+ */
+@ApiTags('Admin')
+@ApiBearerAuth()
+@Controller('admin/servers')
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+export class MonitoringController {
+  private readonly logger = new Logger(MonitoringController.name);
+
+  constructor(private readonly monitoringService: MonitoringService) {}
+
+  /**
+   * 6.1 서버 상태 목록 조회
+   * GET /api/admin/servers
+   */
+  @Get()
+  @ApiOperation({
+    summary: '서버 상태 목록 조회',
+    description: '모든 서버의 상태와 메트릭을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '서버 상태 조회 성공',
+    type: [ServerStatusDto],
+  })
+  async getServers(): Promise<{ data: ServerStatusDto[] }> {
+    this.logger.debug('GET /api/admin/servers');
+    return await this.monitoringService.getServers();
+  }
+
+  /**
+   * 6.2 서버 상세 메트릭 조회
+   * GET /api/admin/servers/:serverName/metrics
+   */
+  @Get(':serverName/metrics')
+  @ApiParam({
+    name: 'serverName',
+    description: '서버 이름',
+    example: 'Main API Server',
+  })
+  @ApiOperation({
+    summary: '서버 상세 메트릭 조회',
+    description: '특정 서버의 시계열 메트릭 데이터를 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '서버 메트릭 조회 성공',
+    type: ServerMetricsDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: '서버를 찾을 수 없음',
+  })
+  async getServerMetrics(
+    @Param('serverName') serverName: string,
+    @Query() query: ServerMetricsQueryDto,
+  ): Promise<{ data: ServerMetricsDto }> {
+    this.logger.debug(`GET /api/admin/servers/${serverName}/metrics`);
+    return await this.monitoringService.getServerMetrics(serverName, query);
+  }
+}
+

--- a/backend/src/modules/admin/monitoring.service.ts
+++ b/backend/src/modules/admin/monitoring.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, Logger, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../db/prisma.service';
+import { ServerStatusDto, ServerMetricsQueryDto, ServerMetricsDto, MetricPointDto } from './dto';
+
+@Injectable()
+export class MonitoringService {
+  private readonly logger = new Logger(MonitoringService.name);
+
+  // 서버 목록 상수 (단일 진실 공급원)
+  private readonly SERVER_CONFIGS = [
+    { name: 'Main API Server', baseCpu: 30, baseMemory: 60, baseResponseTime: 45 },
+    { name: 'Database Server', baseCpu: 25, baseMemory: 55, baseResponseTime: 12 },
+    { name: 'Redis Cache', baseCpu: 15, baseMemory: 42, baseResponseTime: 8 },
+    { name: 'AI Service', baseCpu: 75, baseMemory: 85, baseResponseTime: 150 },
+  ];
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 6.1 서버 상태 목록 조회
+   * GET /api/admin/servers
+   * 
+   * 참고: DashboardService.getServers()와 유사하지만 별도로 구현
+   */
+  async getServers(): Promise<{ data: ServerStatusDto[] }> {
+    this.logger.debug('getServers');
+
+    try {
+      const now = new Date();
+
+      // Mock 데이터 (SERVER_CONFIGS 기반)
+      const servers: ServerStatusDto[] = this.SERVER_CONFIGS.map((config) => {
+        // AI Service는 warning, 나머지는 healthy
+        const status = config.name === 'AI Service' ? 'warning' : 'healthy';
+        
+        // Database와 Redis는 storage 있음
+        const storage = ['Database Server', 'Redis Cache'].includes(config.name)
+          ? this.getRandomInt(30, 70)
+          : undefined;
+
+        return new ServerStatusDto({
+          name: config.name,
+          status,
+          responseTime: config.baseResponseTime + this.getRandomVariance(5),
+          cpu: config.baseCpu + this.getRandomVariance(5),
+          memory: config.baseMemory + this.getRandomVariance(5),
+          connections: this.getRandomInt(300, 1500),
+          storage,
+          lastCheck: now.toISOString(),
+        });
+      });
+
+      return { data: servers };
+    } catch (error) {
+      this.logger.error('Failed to get servers', error);
+      throw new InternalServerErrorException('서버 상태 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 6.2 서버 상세 메트릭 조회
+   * GET /api/admin/servers/:serverName/metrics
+   */
+  async getServerMetrics(serverName: string, query: ServerMetricsQueryDto): Promise<{ data: ServerMetricsDto }> {
+    this.logger.debug(`getServerMetrics serverName=${serverName} period=${query.period}`);
+
+    try {
+      const period = query.period || '1h';
+
+      // 유효한 서버 이름 체크 (SERVER_CONFIGS 기반)
+      const serverConfig = this.SERVER_CONFIGS.find((s) => s.name === serverName);
+      if (!serverConfig) {
+        throw new NotFoundException('서버를 찾을 수 없습니다.');
+      }
+
+      // Mock 데이터 생성 (시간에 따라)
+      const metrics = this.generateMockMetrics(serverConfig, period);
+
+      const result = new ServerMetricsDto({
+        server: serverName,
+        metrics,
+      });
+
+      return { data: result };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error('Failed to get server metrics', error);
+      throw new InternalServerErrorException('서버 메트릭 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * Mock 메트릭 데이터 생성 헬퍼
+   */
+  private generateMockMetrics(
+    serverConfig: { name: string; baseCpu: number; baseMemory: number; baseResponseTime: number },
+    period: string,
+  ): MetricPointDto[] {
+    const now = new Date();
+    const metrics: MetricPointDto[] = [];
+
+    // 기간별 데이터 포인트 개수
+    let dataPoints = 12; // 1h (5분 간격)
+    let intervalMinutes = 5;
+
+    if (period === '24h') {
+      dataPoints = 24; // 24시간 (1시간 간격)
+      intervalMinutes = 60;
+    } else if (period === '7d') {
+      dataPoints = 168; // 7일 (1시간 간격)
+      intervalMinutes = 60;
+    }
+
+    // 데이터 생성
+    for (let i = dataPoints - 1; i >= 0; i--) {
+      const timestamp = new Date(now.getTime() - i * intervalMinutes * 60 * 1000);
+
+      metrics.push({
+        timestamp: timestamp.toISOString(),
+        cpu: Math.max(0, Math.min(100, serverConfig.baseCpu + this.getRandomVariance(10))),
+        memory: Math.max(0, Math.min(100, serverConfig.baseMemory + this.getRandomVariance(8))),
+        responseTime: Math.max(1, serverConfig.baseResponseTime + this.getRandomVariance(15)),
+      });
+    }
+
+    return metrics;
+  }
+
+  /**
+   * 랜덤 변동값 생성
+   */
+  private getRandomVariance(range: number): number {
+    return Math.floor(Math.random() * range * 2) - range;
+  }
+
+  /**
+   * 랜덤 정수 생성
+   */
+  private getRandomInt(min: number, max: number): number {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+}
+

--- a/backend/src/modules/admin/plans.controller.ts
+++ b/backend/src/modules/admin/plans.controller.ts
@@ -1,0 +1,147 @@
+import { Controller, Get, Post, Put, Delete, Param, Body, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminOnlyGuard } from './guards/admin-only.guard';
+import { AdminRoleGuard } from './guards';
+import { PlansService } from './plans.service';
+import { CreatePlanDto, UpdatePlanDto, PlanDto, PlanHistoryDto } from './dto';
+
+/**
+ * Plans Controller (Admin)
+ * Base URL: /api/admin/plans
+ * 
+ * 관리자용 요금제 관리
+ */
+@ApiTags('Admin')
+@ApiBearerAuth()
+@Controller('admin/plans')
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+export class PlansController {
+  private readonly logger = new Logger(PlansController.name);
+
+  constructor(private readonly plansService: PlansService) {}
+
+  /**
+   * 요금제 목록 조회
+   * GET /api/admin/plans
+   */
+  @Get()
+  @ApiOperation({
+    summary: '요금제 목록 조회',
+    description: '모든 요금제 목록을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '요금제 목록 조회 성공',
+    type: [PlanDto],
+  })
+  async getPlans(): Promise<{ data: PlanDto[] }> {
+    this.logger.debug('GET /api/admin/plans');
+    return await this.plansService.getPlans();
+  }
+
+  /**
+   * 요금제 생성
+   * POST /api/admin/plans
+   */
+  @Post()
+  @UseGuards(JwtAuthGuard, AdminOnlyGuard)
+  @ApiOperation({
+    summary: '요금제 생성',
+    description: '새로운 요금제를 생성합니다. (admin 권한 필요)',
+  })
+  @ApiResponse({
+    status: 201,
+    description: '요금제 생성 성공',
+    type: PlanDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 또는 중복된 요금제 이름',
+  })
+  async createPlan(@Body() dto: CreatePlanDto): Promise<{ data: PlanDto }> {
+    this.logger.debug(`POST /api/admin/plans name=${dto.name}`);
+    return await this.plansService.createPlan(dto);
+  }
+
+  /**
+   * 요금제 수정
+   * PUT /api/admin/plans/:planId
+   */
+  @Put(':planId')
+  @UseGuards(JwtAuthGuard, AdminOnlyGuard)
+  @ApiOperation({
+    summary: '요금제 수정',
+    description: '요금제 정보를 수정합니다. (admin 권한 필요)',
+  })
+  @ApiParam({ name: 'planId', description: '요금제 ID', example: 'plan-free' })
+  @ApiResponse({
+    status: 200,
+    description: '요금제 수정 성공',
+    type: PlanDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: '요금제를 찾을 수 없음',
+  })
+  async updatePlan(
+    @Param('planId') planId: string,
+    @Body() dto: UpdatePlanDto,
+  ): Promise<{ data: PlanDto }> {
+    this.logger.debug(`PUT /api/admin/plans/${planId}`);
+    return await this.plansService.updatePlan(planId, dto);
+  }
+
+  /**
+   * 요금제 삭제
+   * DELETE /api/admin/plans/:planId
+   */
+  @Delete(':planId')
+  @UseGuards(JwtAuthGuard, AdminOnlyGuard)
+  @ApiOperation({
+    summary: '요금제 삭제',
+    description: '요금제를 삭제합니다. 구독자가 있는 경우 삭제할 수 없습니다. (admin 권한 필요)',
+  })
+  @ApiParam({ name: 'planId', description: '요금제 ID', example: 'plan-free' })
+  @ApiResponse({
+    status: 200,
+    description: '요금제 삭제 성공',
+  })
+  @ApiResponse({
+    status: 400,
+    description: '구독자가 있어 삭제할 수 없음',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '요금제를 찾을 수 없음',
+  })
+  async deletePlan(@Param('planId') planId: string): Promise<{ message: string }> {
+    this.logger.debug(`DELETE /api/admin/plans/${planId}`);
+    return await this.plansService.deletePlan(planId);
+  }
+
+  /**
+   * 요금제 변경 이력 조회
+   * GET /api/admin/plans/:planId/history
+   */
+  @Get(':planId/history')
+  @ApiOperation({
+    summary: '요금제 변경 이력 조회',
+    description: '요금제의 변경 이력을 조회합니다.',
+  })
+  @ApiParam({ name: 'planId', description: '요금제 ID', example: 'plan-student-pro' })
+  @ApiResponse({
+    status: 200,
+    description: '변경 이력 조회 성공',
+    type: [PlanHistoryDto],
+  })
+  @ApiResponse({
+    status: 404,
+    description: '요금제를 찾을 수 없음',
+  })
+  async getPlanHistory(@Param('planId') planId: string): Promise<{ data: PlanHistoryDto[] }> {
+    this.logger.debug(`GET /api/admin/plans/${planId}/history`);
+    return await this.plansService.getPlanHistory(planId);
+  }
+}
+

--- a/backend/src/modules/admin/plans.service.spec.ts
+++ b/backend/src/modules/admin/plans.service.spec.ts
@@ -1,0 +1,365 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PlansService } from './plans.service';
+import { PrismaService } from '../db/prisma.service';
+
+describe('PlansService', () => {
+  let service: PlansService;
+  let prismaService: any;
+
+  // Default mock plans
+  const mockPlansData = [
+    {
+      id: 'plan-free',
+      name: '무료 플랜',
+      description: '제한된 기능으로 서비스를 체험하세요.',
+      monthlyPrice: 0,
+      yearlyPrice: 0,
+      status: 'active',
+      features: [
+        { key: 'notes', name: '노트 생성', enabled: true, limit: 10, unit: '개' },
+        { key: 'storage', name: '저장 공간', enabled: true, limit: 500, unit: 'MB' },
+        { key: 'ai_summary', name: 'AI 요약', enabled: false, limit: null, unit: null },
+      ],
+      subscriptions: Array(12847).fill({ status: 'active', cancelledAt: null }),
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      updatedAt: new Date('2024-11-15T10:00:00Z'),
+    },
+    {
+      id: 'plan-student-pro',
+      name: 'Student Pro',
+      description: '학생을 위한 프로 플랜',
+      monthlyPrice: 4500,
+      yearlyPrice: 45000,
+      status: 'active',
+      features: [
+        { key: 'notes', name: '노트 생성', enabled: true, limit: 100, unit: '개' },
+        { key: 'storage', name: '저장 공간', enabled: true, limit: 5000, unit: 'MB' },
+        { key: 'ai_summary', name: 'AI 요약', enabled: true, limit: 50, unit: '회/월' },
+      ],
+      subscriptions: Array(3421).fill({ status: 'active', cancelledAt: null }),
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      updatedAt: new Date('2024-11-15T10:00:00Z'),
+    },
+    {
+      id: 'plan-educator-pro',
+      name: 'Educator Pro',
+      description: '교육자를 위한 프로 플랜',
+      monthlyPrice: 9000,
+      yearlyPrice: 90000,
+      status: 'active',
+      features: [
+        { key: 'notes', name: '노트 생성', enabled: true, limit: 500, unit: '개' },
+        { key: 'storage', name: '저장 공간', enabled: true, limit: 20000, unit: 'MB' },
+        { key: 'ai_summary', name: 'AI 요약', enabled: true, limit: 200, unit: '회/월' },
+      ],
+      subscriptions: Array(1256).fill({ status: 'active', cancelledAt: null }),
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      updatedAt: new Date('2024-11-15T10:00:00Z'),
+    },
+  ];
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      plan: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      planHistory: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+      },
+      subscription: {
+        count: jest.fn(),
+      },
+      auditLog: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlansService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PlansService>(PlansService);
+    prismaService = module.get(PrismaService);
+
+    // Set up default mock behavior
+    prismaService.plan.findMany.mockResolvedValue(mockPlansData);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getPlans', () => {
+    it('should return list of plans', async () => {
+      const result = await service.getPlans();
+
+      expect(result.data).toBeInstanceOf(Array);
+      expect(result.data.length).toBeGreaterThan(0);
+    });
+
+    it('should include default plans', async () => {
+      const result = await service.getPlans();
+
+      const planNames = result.data.map((p) => p.name);
+      expect(planNames).toContain('무료 플랜');
+      expect(planNames).toContain('Student Pro');
+      expect(planNames).toContain('Educator Pro');
+    });
+
+    it('should return plans with required fields', async () => {
+      const result = await service.getPlans();
+
+      result.data.forEach((plan) => {
+        expect(plan).toHaveProperty('id');
+        expect(plan).toHaveProperty('name');
+        expect(plan).toHaveProperty('description');
+        expect(plan).toHaveProperty('monthlyPrice');
+        expect(plan).toHaveProperty('yearlyPrice');
+        expect(plan).toHaveProperty('status');
+        expect(plan).toHaveProperty('features');
+        expect(plan).toHaveProperty('subscriberCount');
+      });
+    });
+  });
+
+  describe('createPlan', () => {
+    it('should create a new plan', async () => {
+      const newPlan = {
+        name: 'Test Plan',
+        description: 'Test Description',
+        monthlyPrice: 10000,
+        yearlyPrice: 100000,
+        status: 'active' as const,
+        features: [
+          {
+            key: 'test',
+            name: 'Test Feature',
+            enabled: true,
+            limit: 10,
+            unit: '개',
+          },
+        ],
+      };
+
+      const createdPlan = {
+        id: 'plan-test',
+        ...newPlan,
+        subscriptions: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      prismaService.plan.create.mockResolvedValue(createdPlan);
+
+      const result = await service.createPlan(newPlan);
+
+      expect(result.data.name).toBe('Test Plan');
+      expect(result.data.id).toBeDefined();
+    });
+
+    it('should throw BadRequestException for duplicate plan name', async () => {
+      const plan = {
+        name: '무료 플랜', // Already exists
+        description: 'Test',
+        monthlyPrice: 0,
+        yearlyPrice: 0,
+        status: 'active' as const,
+        features: [],
+      };
+
+      // Simulate Prisma unique constraint error
+      prismaService.plan.create.mockRejectedValue({
+        code: 'P2002',
+        meta: { target: ['name'] },
+      });
+
+      await expect(service.createPlan(plan)).rejects.toThrow();
+    });
+
+    it('should validate monthly price is non-negative', async () => {
+      const plan = {
+        name: 'Invalid Plan',
+        description: 'Test',
+        monthlyPrice: -100, // Invalid
+        yearlyPrice: 0,
+        status: 'active' as const,
+        features: [],
+      };
+
+      const createdPlan = {
+        id: 'plan-invalid',
+        ...plan,
+        subscriptions: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      prismaService.plan.create.mockResolvedValue(createdPlan);
+
+      // This should be caught by DTO validation, but testing service level
+      const result = await service.createPlan(plan);
+      expect(result.data.monthlyPrice).toBe(-100); // Service doesn't validate, DTO does
+    });
+  });
+
+  describe('updatePlan', () => {
+    it('should update an existing plan', async () => {
+      const planId = 'plan-free';
+      const updatedPlan = {
+        ...mockPlansData[0],
+        monthlyPrice: 5000,
+      };
+
+      prismaService.plan.findUnique.mockResolvedValue(mockPlansData[0]);
+      prismaService.plan.findMany.mockResolvedValue([mockPlansData[0]]);
+      prismaService.plan.update.mockResolvedValue(updatedPlan);
+      prismaService.planHistory.create.mockResolvedValue({});
+
+      const result = await service.updatePlan(planId, {
+        monthlyPrice: 5000,
+      });
+
+      expect(result.data.monthlyPrice).toBe(5000);
+    });
+
+    it('should throw NotFoundException for non-existent plan', async () => {
+      prismaService.plan.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updatePlan('non-existent-id', { monthlyPrice: 5000 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException for duplicate name', async () => {
+      const planId = 'plan-student-pro';
+      const existingName = '무료 플랜';
+
+      prismaService.plan.findUnique.mockResolvedValue(mockPlansData[1]);
+      // Simulate Prisma unique constraint error
+      prismaService.plan.update.mockRejectedValue({
+        code: 'P2002',
+        meta: { target: ['name'] },
+      });
+
+      await expect(
+        service.updatePlan(planId, { name: existingName }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('deletePlan', () => {
+    it('should delete a plan without subscribers', async () => {
+      const newPlan = {
+        id: 'plan-to-delete',
+        name: 'To Be Deleted',
+        description: 'Test',
+        monthlyPrice: 0,
+        yearlyPrice: 0,
+        status: 'inactive',
+        features: [],
+        subscriptions: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      prismaService.plan.findUnique.mockResolvedValue(newPlan);
+      prismaService.subscription.count.mockResolvedValue(0);
+      prismaService.plan.delete.mockResolvedValue(newPlan);
+
+      await expect(service.deletePlan(newPlan.id)).resolves.not.toThrow();
+    });
+
+    it('should throw NotFoundException for non-existent plan', async () => {
+      prismaService.plan.findUnique.mockResolvedValue(null);
+
+      await expect(service.deletePlan('non-existent-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException when plan has subscribers', async () => {
+      const planWithSubscribers = mockPlansData[0];
+
+      prismaService.plan.findUnique.mockResolvedValue(planWithSubscribers);
+      prismaService.subscription.count.mockResolvedValue(100);
+
+      await expect(service.deletePlan(planWithSubscribers.id)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('getPlanHistory', () => {
+    it('should return plan history', async () => {
+      const planId = 'plan-free';
+      const mockAuditLogs = [
+        {
+          id: 'audit-1',
+          userId: 'admin-user',
+          action: 'PLAN_UPDATE',
+          resourceId: planId,
+          payload: { changes: { monthlyPrice: { from: 0, to: 6000 } } },
+          at: new Date(),
+          method: 'PUT',
+          path: '/api/admin/plans',
+        },
+      ];
+
+      prismaService.plan.findUnique.mockResolvedValue(mockPlansData[0]);
+      prismaService.auditLog.findMany.mockResolvedValue(mockAuditLogs);
+
+      const result = await service.getPlanHistory(planId);
+
+      expect(result.data).toBeInstanceOf(Array);
+      expect(result.data.length).toBeGreaterThan(0);
+    });
+
+    it('should throw NotFoundException for non-existent plan', async () => {
+      prismaService.plan.findUnique.mockResolvedValue(null);
+
+      await expect(service.getPlanHistory('non-existent-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should include change details in history', async () => {
+      const planId = 'plan-free';
+      const mockAuditLogs = [
+        {
+          id: 'audit-1',
+          userId: 'admin-user',
+          action: 'PLAN_UPDATE',
+          resourceId: planId,
+          payload: { changes: { monthlyPrice: { from: 0, to: 7000 } } },
+          at: new Date(),
+          method: 'PUT',
+          path: '/api/admin/plans',
+        },
+      ];
+
+      prismaService.plan.findUnique.mockResolvedValue(mockPlansData[0]);
+      prismaService.auditLog.findMany.mockResolvedValue(mockAuditLogs);
+
+      const result = await service.getPlanHistory(planId);
+
+      expect(result.data[0]).toHaveProperty('id');
+      expect(result.data[0]).toHaveProperty('planId');
+      expect(result.data[0]).toHaveProperty('changedBy');
+      expect(result.data[0]).toHaveProperty('changes');
+      expect(result.data[0]).toHaveProperty('createdAt');
+    });
+  });
+});

--- a/backend/src/modules/admin/plans.service.ts
+++ b/backend/src/modules/admin/plans.service.ts
@@ -1,0 +1,276 @@
+import { Injectable, Logger, NotFoundException, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { PrismaService } from '../db/prisma.service';
+import { CreatePlanDto, UpdatePlanDto, PlanDto, PlanHistoryDto, PlanChangeDto } from './dto';
+
+@Injectable()
+export class PlansService {
+  private readonly logger = new Logger(PlansService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 요금제 목록 조회
+   * GET /api/admin/plans
+   */
+  async getPlans(): Promise<{ data: PlanDto[] }> {
+    this.logger.debug('getPlans');
+
+    try {
+      const plans = await this.prisma.plan.findMany({
+        orderBy: { createdAt: 'desc' },
+        include: {
+          subscriptions: {
+            where: {
+              status: 'active',
+              cancelledAt: null,
+            },
+          },
+        },
+      });
+
+      const data = plans.map((plan) => new PlanDto({
+        id: plan.id,
+        name: plan.name,
+        description: plan.description,
+        monthlyPrice: plan.monthlyPrice,
+        yearlyPrice: plan.yearlyPrice,
+        status: plan.status,
+        features: plan.features as any,
+        subscriberCount: plan.subscriptions.length,
+        createdAt: plan.createdAt.toISOString(),
+        updatedAt: plan.updatedAt.toISOString(),
+      }));
+
+      return { data };
+    } catch (error) {
+      this.logger.error('Failed to get plans', error);
+      throw new InternalServerErrorException('요금제 목록 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 요금제 생성
+   * POST /api/admin/plans
+   */
+  async createPlan(dto: CreatePlanDto): Promise<{ data: PlanDto }> {
+    this.logger.debug(`createPlan name=${dto.name}`);
+
+    try {
+      // Prisma가 자동으로 ID 생성하도록 함 (cuid)
+      // 이름 중복은 DB의 @unique 제약으로 처리
+      const newPlan = await this.prisma.plan.create({
+        data: {
+          name: dto.name,
+          description: dto.description,
+          monthlyPrice: dto.monthlyPrice,
+          yearlyPrice: dto.yearlyPrice,
+          status: dto.status,
+          features: dto.features as any,
+        },
+        include: {
+          subscriptions: {
+            where: {
+              status: 'active',
+              cancelledAt: null,
+            },
+          },
+        },
+      });
+
+      this.logger.log(`Plan created: ${newPlan.id}`);
+
+      return {
+        data: new PlanDto({
+          id: newPlan.id,
+          name: newPlan.name,
+          description: newPlan.description,
+          monthlyPrice: newPlan.monthlyPrice,
+          yearlyPrice: newPlan.yearlyPrice,
+          status: newPlan.status,
+          features: newPlan.features as any,
+          subscriberCount: newPlan.subscriptions.length,
+          createdAt: newPlan.createdAt.toISOString(),
+          updatedAt: newPlan.updatedAt.toISOString(),
+        }),
+      };
+    } catch (error: any) {
+      // Prisma unique constraint 에러 처리
+      if (error?.code === 'P2002') {
+        throw new BadRequestException('이미 존재하는 요금제 이름입니다.');
+      }
+      this.logger.error('Failed to create plan', error);
+      throw new InternalServerErrorException('요금제 생성에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 요금제 수정
+   * PUT /api/admin/plans/:planId
+   */
+  async updatePlan(planId: string, dto: UpdatePlanDto): Promise<{ data: PlanDto }> {
+    this.logger.debug(`updatePlan planId=${planId}`);
+
+    try {
+      const plan = await this.prisma.plan.findUnique({
+        where: { id: planId },
+        include: {
+          subscriptions: {
+            where: {
+              status: 'active',
+              cancelledAt: null,
+            },
+          },
+        },
+      });
+
+      if (!plan) {
+        throw new NotFoundException('요금제를 찾을 수 없습니다.');
+      }
+
+      // 이름 변경 시 중복 체크는 Prisma unique constraint가 처리
+
+      // 업데이트
+      const updatedPlan = await this.prisma.plan.update({
+        where: { id: planId },
+        data: {
+          ...(dto.name && { name: dto.name }),
+          ...(dto.description && { description: dto.description }),
+          ...(dto.monthlyPrice !== undefined && { monthlyPrice: dto.monthlyPrice }),
+          ...(dto.yearlyPrice !== undefined && { yearlyPrice: dto.yearlyPrice }),
+          ...(dto.status && { status: dto.status }),
+          ...(dto.features && { features: dto.features as any }),
+        },
+        include: {
+          subscriptions: {
+            where: {
+              status: 'active',
+              cancelledAt: null,
+            },
+          },
+        },
+      });
+
+      this.logger.log(`Plan updated: ${planId}`);
+
+      return {
+        data: new PlanDto({
+          id: updatedPlan.id,
+          name: updatedPlan.name,
+          description: updatedPlan.description,
+          monthlyPrice: updatedPlan.monthlyPrice,
+          yearlyPrice: updatedPlan.yearlyPrice,
+          status: updatedPlan.status,
+          features: updatedPlan.features as any,
+          subscriberCount: updatedPlan.subscriptions.length,
+          createdAt: updatedPlan.createdAt.toISOString(),
+          updatedAt: updatedPlan.updatedAt.toISOString(),
+        }),
+      };
+    } catch (error: any) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      // Prisma unique constraint 에러 처리
+      if (error?.code === 'P2002') {
+        throw new BadRequestException('이미 존재하는 요금제 이름입니다.');
+      }
+      this.logger.error('Failed to update plan', error);
+      throw new InternalServerErrorException('요금제 수정에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 요금제 삭제
+   * DELETE /api/admin/plans/:planId
+   */
+  async deletePlan(planId: string): Promise<{ message: string }> {
+    this.logger.debug(`deletePlan planId=${planId}`);
+
+    try {
+      const plan = await this.prisma.plan.findUnique({
+        where: { id: planId },
+        include: {
+          subscriptions: {
+            where: {
+              status: 'active',
+              cancelledAt: null,
+            },
+          },
+        },
+      });
+
+      if (!plan) {
+        throw new NotFoundException('요금제를 찾을 수 없습니다.');
+      }
+
+      // 구독자가 있는지 체크
+      if (plan.subscriptions.length > 0) {
+        throw new BadRequestException('구독자가 있는 요금제는 삭제할 수 없습니다.');
+      }
+
+      await this.prisma.plan.delete({
+        where: { id: planId },
+      });
+
+      this.logger.log(`Plan deleted: ${planId}`);
+
+      return { message: '요금제가 삭제되었습니다.' };
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error('Failed to delete plan', error);
+      throw new InternalServerErrorException('요금제 삭제에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 요금제 변경 이력 조회
+   * GET /api/admin/plans/:planId/history
+   */
+  async getPlanHistory(planId: string): Promise<{ data: PlanHistoryDto[] }> {
+    this.logger.debug(`getPlanHistory planId=${planId}`);
+
+    try {
+      const plan = await this.prisma.plan.findUnique({
+        where: { id: planId },
+      });
+
+      if (!plan) {
+        throw new NotFoundException('요금제를 찾을 수 없습니다.');
+      }
+
+      // 실제 이력 테이블이 없으므로 AuditLog에서 추출
+      // TODO: 실제 PlanHistory 테이블이 추가되면 해당 테이블 사용
+      const auditLogs = await this.prisma.auditLog.findMany({
+        where: {
+          action: 'PLAN_UPDATE',
+          resourceId: planId,
+        },
+        orderBy: { at: 'desc' },
+        take: 20,
+      });
+
+      const history: PlanHistoryDto[] = auditLogs.map((log) => {
+        const payload = log.payload as any;
+        return new PlanHistoryDto({
+          id: log.id,
+          planId,
+          changedBy: log.userId || 'system',
+          changedByName: '시스템 관리자', // TODO: User 테이블에서 이름 조회
+          changes: payload?.changes || [],
+          createdAt: log.at.toISOString(),
+        });
+      });
+
+      return { data: history };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error('Failed to get plan history', error);
+      throw new InternalServerErrorException('요금제 변경 이력 조회에 실패했습니다.');
+    }
+  }
+}
+

--- a/backend/src/modules/admin/settings.controller.ts
+++ b/backend/src/modules/admin/settings.controller.ts
@@ -1,0 +1,61 @@
+import { Controller, Get, Put, Body, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminOnlyGuard } from './guards';
+import { SettingsService } from './settings.service';
+import { SystemSettingsDto, UpdateSystemSettingsDto, UpdateSystemSettingsResponseDto } from './dto';
+
+/**
+ * Settings Controller (Admin)
+ * Base URL: /api/admin/settings
+ * 
+ * 관리자용 시스템 설정
+ */
+@ApiTags('Admin')
+@ApiBearerAuth()
+@Controller('admin/settings')
+@UseGuards(JwtAuthGuard, AdminOnlyGuard)
+export class SettingsController {
+  private readonly logger = new Logger(SettingsController.name);
+
+  constructor(private readonly settingsService: SettingsService) {}
+
+  /**
+   * 7.1 시스템 설정 조회
+   * GET /api/admin/settings
+   */
+  @Get()
+  @ApiOperation({
+    summary: '시스템 설정 조회',
+    description: '현재 시스템 설정을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '설정 조회 성공',
+    type: SystemSettingsDto,
+  })
+  async getSettings(): Promise<{ data: SystemSettingsDto }> {
+    this.logger.debug('GET /api/admin/settings');
+    return await this.settingsService.getSettings();
+  }
+
+  /**
+   * 7.2 시스템 설정 저장
+   * PUT /api/admin/settings
+   */
+  @Put()
+  @ApiOperation({
+    summary: '시스템 설정 저장',
+    description: '시스템 설정을 업데이트합니다. (environment는 읽기 전용)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '설정 저장 성공',
+    type: UpdateSystemSettingsResponseDto,
+  })
+  async updateSettings(@Body() dto: UpdateSystemSettingsDto): Promise<UpdateSystemSettingsResponseDto> {
+    this.logger.debug('PUT /api/admin/settings');
+    return await this.settingsService.updateSettings(dto);
+  }
+}
+

--- a/backend/src/modules/admin/settings.service.ts
+++ b/backend/src/modules/admin/settings.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger, InternalServerErrorException } from '@nestjs/common';
+import { PrismaService } from '../db/prisma.service';
+import {
+  SystemSettingsDto,
+  UpdateSystemSettingsDto,
+  UpdateSystemSettingsResponseDto,
+  GeneralSettingsDto,
+  SecuritySettingsDto,
+  EnvironmentSettingsDto,
+} from './dto';
+
+@Injectable()
+export class SettingsService {
+  private readonly logger = new Logger(SettingsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 기본 설정값
+   */
+  private getDefaultSettings(): SystemSettingsDto {
+    return new SystemSettingsDto({
+      general: {
+        maintenanceMode: false,
+        maxUploadSize: 100,
+        sessionTimeout: 60,
+      },
+      security: {
+        requireEmailVerification: true,
+        maxLoginAttempts: 5,
+        lockoutDuration: 30,
+      },
+      environment: {
+        version: '1.0.0',
+        environment: process.env.NODE_ENV || 'development',
+        apiUrl: process.env.API_URL || 'http://localhost:4000',
+        mockMode: process.env.NODE_ENV === 'development',
+      },
+    });
+  }
+
+  /**
+   * 7.1 시스템 설정 조회
+   * GET /api/admin/settings
+   */
+  async getSettings(): Promise<{ data: SystemSettingsDto }> {
+    this.logger.debug('getSettings');
+
+    try {
+      // DB에서 설정 조회
+      const [generalSettings, securitySettings] = await Promise.all([
+        this.prisma.systemSettings.findUnique({ where: { key: 'general' } }),
+        this.prisma.systemSettings.findUnique({ where: { key: 'security' } }),
+      ]);
+
+      const defaults = this.getDefaultSettings();
+
+      // DB 값이 있으면 사용, 없으면 기본값
+      const settings = new SystemSettingsDto({
+        general: generalSettings ? (generalSettings.value as any) : defaults.general,
+        security: securitySettings ? (securitySettings.value as any) : defaults.security,
+        environment: defaults.environment, // 환경 설정은 항상 실시간 값 사용
+      });
+
+      return { data: settings };
+    } catch (error) {
+      this.logger.error('Failed to get settings', error);
+      throw new InternalServerErrorException('설정 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 7.2 시스템 설정 저장
+   * PUT /api/admin/settings
+   */
+  async updateSettings(dto: UpdateSystemSettingsDto): Promise<UpdateSystemSettingsResponseDto> {
+    this.logger.debug(`updateSettings dto=${JSON.stringify(dto)}`);
+
+    try {
+      const updates: Promise<any>[] = [];
+
+      // general 설정 저장 (Deep merge)
+      if (dto.general) {
+        const existing = await this.prisma.systemSettings.findUnique({
+          where: { key: 'general' },
+        });
+        
+        const merged = existing?.value
+          ? { ...(existing.value as any), ...dto.general }
+          : dto.general;
+
+        updates.push(
+          this.prisma.systemSettings.upsert({
+            where: { key: 'general' },
+            create: {
+              key: 'general',
+              value: merged as any,
+            },
+            update: {
+              value: merged as any,
+            },
+          })
+        );
+      }
+
+      // security 설정 저장 (Deep merge)
+      if (dto.security) {
+        const existing = await this.prisma.systemSettings.findUnique({
+          where: { key: 'security' },
+        });
+        
+        const merged = existing?.value
+          ? { ...(existing.value as any), ...dto.security }
+          : dto.security;
+
+        updates.push(
+          this.prisma.systemSettings.upsert({
+            where: { key: 'security' },
+            create: {
+              key: 'security',
+              value: merged as any,
+            },
+            update: {
+              value: merged as any,
+            },
+          })
+        );
+      }
+
+      await Promise.all(updates);
+
+      // 업데이트된 설정 조회
+      const updatedSettings = await this.getSettings();
+
+      this.logger.log('Settings updated successfully');
+
+      return new UpdateSystemSettingsResponseDto({
+        success: true,
+        message: '설정이 저장되었습니다.',
+        data: updatedSettings.data,
+      });
+    } catch (error) {
+      this.logger.error('Failed to update settings', error);
+      throw new InternalServerErrorException('설정 저장에 실패했습니다.');
+    }
+  }
+}
+

--- a/backend/src/modules/admin/subscriptions.controller.ts
+++ b/backend/src/modules/admin/subscriptions.controller.ts
@@ -1,0 +1,151 @@
+import { Controller, Get, Query, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from './guards';
+import { SubscriptionsService } from './subscriptions.service';
+import {
+  SubscriptionStatsQueryDto,
+  SubscriptionStatsDto,
+  RevenueQueryDto,
+  RevenueItemDto,
+  SubscriptionByPlanDto,
+  ChurnAnalysisDto,
+  SubscriptionListQueryDto,
+  SubscriptionItemDto,
+  PlanDistributionDto,
+  PaginationDto,
+} from './dto';
+
+/**
+ * Subscriptions Controller (Admin)
+ * Base URL: /api/admin/subscriptions
+ * 
+ * 관리자용 구독 분석
+ */
+@ApiTags('Admin')
+@ApiBearerAuth()
+@Controller('admin/subscriptions')
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+export class SubscriptionsController {
+  private readonly logger = new Logger(SubscriptionsController.name);
+
+  constructor(private readonly subscriptionsService: SubscriptionsService) {}
+
+  /**
+   * 5.1 구독 통계 조회
+   * GET /api/admin/subscriptions/stats
+   */
+  @Get('stats')
+  @ApiOperation({
+    summary: '구독 통계 조회',
+    description: '전체 수익, MRR, 이탈률 등 구독 관련 주요 지표를 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '구독 통계 조회 성공',
+    type: SubscriptionStatsDto,
+  })
+  async getStats(@Query() query: SubscriptionStatsQueryDto): Promise<{ data: SubscriptionStatsDto }> {
+    this.logger.debug('GET /api/admin/subscriptions/stats');
+    return await this.subscriptionsService.getStats(query);
+  }
+
+  /**
+   * 5.2 수익 추이 조회
+   * GET /api/admin/subscriptions/revenue
+   */
+  @Get('revenue')
+  @ApiOperation({
+    summary: '수익 추이 조회',
+    description: '기간별 수익 추이를 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '수익 추이 조회 성공',
+    type: [RevenueItemDto],
+  })
+  async getRevenue(@Query() query: RevenueQueryDto): Promise<{ data: RevenueItemDto[] }> {
+    this.logger.debug('GET /api/admin/subscriptions/revenue');
+    return await this.subscriptionsService.getRevenue(query);
+  }
+
+  /**
+   * 5.3 요금제별 분석
+   * GET /api/admin/subscriptions/by-plan
+   */
+  @Get('by-plan')
+  @ApiOperation({
+    summary: '요금제별 분석',
+    description: '각 요금제의 구독자 수, 수익 등을 분석합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '요금제별 분석 성공',
+    type: [SubscriptionByPlanDto],
+  })
+  async getByPlan(): Promise<{ data: SubscriptionByPlanDto[] }> {
+    this.logger.debug('GET /api/admin/subscriptions/by-plan');
+    return await this.subscriptionsService.getByPlan();
+  }
+
+  /**
+   * 5.4 이탈 분석
+   * GET /api/admin/subscriptions/churn
+   */
+  @Get('churn')
+  @ApiOperation({
+    summary: '이탈 분석',
+    description: '이탈률, 이탈 사유 등을 분석합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '이탈 분석 성공',
+    type: ChurnAnalysisDto,
+  })
+  async getChurn(@Query() query: SubscriptionStatsQueryDto): Promise<{ data: ChurnAnalysisDto }> {
+    this.logger.debug('GET /api/admin/subscriptions/churn');
+    return await this.subscriptionsService.getChurn(query);
+  }
+
+  /**
+   * 5.6 요금제 분포
+   * GET /api/admin/subscriptions/distribution
+   */
+  @Get('distribution')
+  @ApiOperation({
+    summary: '요금제 분포 조회',
+    description: '각 요금제의 사용자 수와 비율을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '요금제 분포 조회 성공',
+    type: [PlanDistributionDto],
+  })
+  async getDistribution(): Promise<{ data: PlanDistributionDto[] }> {
+    this.logger.debug('GET /api/admin/subscriptions/distribution');
+    return await this.subscriptionsService.getDistribution();
+  }
+
+  /**
+   * 5.5 구독 목록 조회
+   * GET /api/admin/subscriptions
+   * 
+   * ⚠️ 주의: @Get()은 항상 맨 마지막에 위치해야 함!
+   */
+  @Get()
+  @ApiOperation({
+    summary: '구독 목록 조회',
+    description: '전체 구독 목록을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '구독 목록 조회 성공',
+  })
+  async getSubscriptions(
+    @Query() query: SubscriptionListQueryDto,
+  ): Promise<{ data: SubscriptionItemDto[]; pagination: PaginationDto }> {
+    this.logger.debug('GET /api/admin/subscriptions');
+    return await this.subscriptionsService.getSubscriptions(query);
+  }
+}
+

--- a/backend/src/modules/admin/subscriptions.service.ts
+++ b/backend/src/modules/admin/subscriptions.service.ts
@@ -1,0 +1,654 @@
+import { Injectable, Logger, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { PrismaService } from '../db/prisma.service';
+import {
+  SubscriptionStatsQueryDto,
+  SubscriptionStatsDto,
+  RevenueQueryDto,
+  RevenueItemDto,
+  SubscriptionByPlanDto,
+  ChurnAnalysisDto,
+  SubscriptionListQueryDto,
+  SubscriptionItemDto,
+  PlanDistributionDto,
+  PaginationDto,
+} from './dto';
+
+@Injectable()
+export class SubscriptionsService {
+  private readonly logger = new Logger(SubscriptionsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 5.1 구독 통계 조회
+   * GET /api/admin/subscriptions/stats
+   */
+  async getStats(query: SubscriptionStatsQueryDto): Promise<{ data: SubscriptionStatsDto }> {
+    this.logger.debug(`getStats period=${query.period}`);
+
+    try {
+      const now = new Date();
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const sixtyDaysAgo = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000);
+
+      // 현재 활성 구독자 수 (status가 'active'이고 cancelledAt이 null)
+      const subscriberCount = await this.prisma.subscription.count({
+        where: {
+          status: 'active',
+          cancelledAt: null,
+        },
+      });
+
+      // 30일 전 활성 구독자 수 (30일 전 시점에 활성 상태였던 구독)
+      const subscriberCountThirtyDaysAgo = await this.prisma.subscription.count({
+        where: {
+          status: 'active',
+          createdAt: { lte: thirtyDaysAgo },
+          OR: [
+            { cancelledAt: null },
+            { cancelledAt: { gt: thirtyDaysAgo } },
+          ],
+        },
+      });
+
+      // 총 수익 (모든 활성 구독의 월간 금액 합계)
+      // status가 'active'이고 cancelledAt이 null인 구독만 활성으로 간주
+      const activeSubscriptions = await this.prisma.subscription.findMany({
+        where: {
+          status: 'active',
+          cancelledAt: null,
+        },
+        select: { amount: true, billingCycle: true },
+      });
+
+      let totalRevenue = 0;
+      let mrr = 0; // Monthly Recurring Revenue
+      for (const sub of activeSubscriptions) {
+        if (sub.billingCycle === 'monthly') {
+          totalRevenue += sub.amount * 12; // 연간 수익으로 환산
+          mrr += sub.amount;
+        } else if (sub.billingCycle === 'yearly') {
+          totalRevenue += sub.amount;
+          mrr += Math.round(sub.amount / 12); // 연간을 월간으로 환산
+        }
+      }
+
+      // 30일 전 MRR 계산 (30일 전 시점에 활성 상태였던 구독)
+      const subscriptionsThirtyDaysAgo = await this.prisma.subscription.findMany({
+        where: {
+          status: 'active',
+          createdAt: { lte: thirtyDaysAgo },
+          OR: [
+            { cancelledAt: null },
+            { cancelledAt: { gt: thirtyDaysAgo } },
+          ],
+        },
+        select: { amount: true, billingCycle: true },
+      });
+
+      let mrrThirtyDaysAgo = 0;
+      for (const sub of subscriptionsThirtyDaysAgo) {
+        if (sub.billingCycle === 'monthly') {
+          mrrThirtyDaysAgo += sub.amount;
+        } else if (sub.billingCycle === 'yearly') {
+          mrrThirtyDaysAgo += Math.round(sub.amount / 12);
+        }
+      }
+
+      // 이탈률 계산 (최근 30일간 취소된 구독)
+      const churnedCount = await this.prisma.subscription.count({
+        where: {
+          status: 'cancelled',
+          cancelledAt: { gte: thirtyDaysAgo },
+        },
+      });
+
+      // 이탈률은 기간 시작 시점의 활성 구독자 수로 나눠야 함
+      const churnRate = subscriberCountThirtyDaysAgo > 0
+        ? (churnedCount / subscriberCountThirtyDaysAgo) * 100
+        : 0;
+
+      // 30-60일 전 이탈자 수
+      const churnedCountPrevious = await this.prisma.subscription.count({
+        where: {
+          status: 'cancelled',
+          cancelledAt: {
+            gte: sixtyDaysAgo,
+            lt: thirtyDaysAgo,
+          },
+        },
+      });
+
+      // ARPU (Average Revenue Per User)
+      const arpu = subscriberCount > 0 ? Math.round(mrr / subscriberCount) : 0;
+
+      // LTV (Lifetime Value) - 간단히 ARPU * 평균 구독 기간 (월)로 계산
+      // 실제로는 더 복잡한 계산이 필요하지만 데모용으로 단순화
+      const avgSubscriptionMonths = 12; // 가정
+      const ltv = arpu * avgSubscriptionMonths;
+
+      const stats = new SubscriptionStatsDto({
+        totalRevenue,
+        totalRevenueChange: this.calculateChangeRate(0, totalRevenue), // 이전 데이터 없으므로 0
+        subscriberCount,
+        subscriberCountChange: this.calculateChangeRate(subscriberCountThirtyDaysAgo, subscriberCount),
+        mrr,
+        mrrChange: this.calculateChangeRate(mrrThirtyDaysAgo, mrr),
+        churnRate: Math.round(churnRate * 10) / 10,
+        churnRateChange: this.calculateChangeRate(churnedCountPrevious, churnedCount),
+        arpu,
+        ltv,
+      });
+
+      return { data: stats };
+    } catch (error) {
+      this.logger.error('Failed to get subscription stats', error);
+      throw new InternalServerErrorException('구독 통계 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 변화율 계산 (백분율)
+   */
+  private calculateChangeRate(oldValue: number, newValue: number): number {
+    if (oldValue === 0) {
+      return newValue > 0 ? 100 : 0;
+    }
+    const change = ((newValue - oldValue) / oldValue) * 100;
+    return Math.round(change * 10) / 10;
+  }
+
+  /**
+   * 5.2 수익 추이 조회
+   * GET /api/admin/subscriptions/revenue
+   */
+  async getRevenue(query: RevenueQueryDto): Promise<{ data: RevenueItemDto[] }> {
+    this.logger.debug(`getRevenue startDate=${query.startDate} endDate=${query.endDate}`);
+
+    try {
+      const startDate = query.startDate ? new Date(query.startDate) : new Date();
+      startDate.setMonth(startDate.getMonth() - 6); // 기본 6개월
+      const endDate = query.endDate ? new Date(query.endDate) : new Date();
+
+      // 월별로 그룹화하여 수익 계산
+      const revenue: RevenueItemDto[] = [];
+      const current = new Date(startDate);
+      current.setDate(1); // 월 초일로 설정
+      current.setHours(0, 0, 0, 0);
+
+      while (current <= endDate) {
+        const monthStart = new Date(current);
+        const monthEnd = new Date(current);
+        monthEnd.setMonth(monthEnd.getMonth() + 1);
+        monthEnd.setDate(0); // 월 말일
+        monthEnd.setHours(23, 59, 59, 999);
+
+        // 해당 월 신규 구독
+        const newSubscriptions = await this.prisma.subscription.count({
+          where: {
+            createdAt: {
+              gte: monthStart,
+              lte: monthEnd,
+            },
+          },
+        });
+
+        // 해당 월 말일 기준 활성 구독 수 (월 말일 시점에 활성 상태였던 구독)
+        const subscriptions = await this.prisma.subscription.count({
+          where: {
+            status: 'active',
+            createdAt: { lte: monthEnd },
+            OR: [
+              { cancelledAt: null },
+              { cancelledAt: { gt: monthEnd } },
+            ],
+          },
+        });
+
+        // 해당 월 취소된 구독
+        const cancellations = await this.prisma.subscription.count({
+          where: {
+            status: 'cancelled',
+            cancelledAt: {
+              gte: monthStart,
+              lte: monthEnd,
+            },
+          },
+        });
+
+        // 해당 월 수익 계산 (월 말일 시점에 활성 상태였던 구독의 월간 금액 합계)
+        const activeSubs = await this.prisma.subscription.findMany({
+          where: {
+            status: 'active',
+            createdAt: { lte: monthEnd },
+            OR: [
+              { cancelledAt: null },
+              { cancelledAt: { gt: monthEnd } },
+            ],
+          },
+          select: { 
+            amount: true, 
+            billingCycle: true,
+            currentPeriodStart: true,
+            createdAt: true,
+          },
+        });
+
+        let monthlyRevenue = 0;
+        let renewals = 0;
+        for (const sub of activeSubs) {
+          if (sub.billingCycle === 'monthly') {
+            monthlyRevenue += sub.amount;
+            // 갱신: currentPeriodStart가 해당 월에 있고, createdAt이 그보다 이전이면 갱신
+            if (
+              sub.currentPeriodStart >= monthStart &&
+              sub.currentPeriodStart <= monthEnd &&
+              sub.createdAt < sub.currentPeriodStart
+            ) {
+              renewals++;
+            }
+          } else if (sub.billingCycle === 'yearly') {
+            monthlyRevenue += Math.round(sub.amount / 12);
+            // 연간 구독도 마찬가지로 갱신 체크
+            if (
+              sub.currentPeriodStart >= monthStart &&
+              sub.currentPeriodStart <= monthEnd &&
+              sub.createdAt < sub.currentPeriodStart
+            ) {
+              renewals++;
+            }
+          }
+        }
+
+        const month = current.getMonth() + 1;
+        const dateStr = `${current.getFullYear()}-${month < 10 ? '0' : ''}${month}`;
+        revenue.push({
+          date: dateStr,
+          revenue: monthlyRevenue,
+          subscriptions,
+          newSubscriptions,
+          renewals,
+          cancellations,
+        });
+
+        current.setMonth(current.getMonth() + 1);
+      }
+
+      return { data: revenue };
+    } catch (error) {
+      this.logger.error('Failed to get revenue', error);
+      throw new InternalServerErrorException('수익 추이 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 5.3 요금제별 분석
+   * GET /api/admin/subscriptions/by-plan
+   */
+  async getByPlan(): Promise<{ data: SubscriptionByPlanDto[] }> {
+    this.logger.debug('getByPlan');
+
+    try {
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+      // 모든 활성 요금제 조회
+      const plans = await this.prisma.plan.findMany({
+        where: { status: 'active' },
+        include: {
+          subscriptions: {
+            where: {
+              status: 'active',
+              cancelledAt: null,
+            },
+          },
+        },
+      });
+
+      // 전체 활성 구독자 수 (루프 밖에서 한 번만 조회)
+      const totalSubscribers = await this.prisma.subscription.count({
+        where: {
+          status: 'active',
+          cancelledAt: null,
+        },
+      });
+
+      // 각 플랜별로 30일 전 구독자 수를 병렬로 조회
+      const planIds = plans.map(p => p.id);
+      const thirtyDaysAgoCountsPromises = planIds.map(planId =>
+        this.prisma.subscription.count({
+          where: {
+            planId,
+            status: 'active',
+            createdAt: { lte: thirtyDaysAgo },
+            OR: [
+              { cancelledAt: null },
+              { cancelledAt: { gt: thirtyDaysAgo } },
+            ],
+          },
+        })
+      );
+
+      const thirtyDaysAgoCounts = await Promise.all(thirtyDaysAgoCountsPromises);
+
+      // 각 플랜별로 평균 구독 기간을 병렬로 조회
+      const avgLengthPromises = plans.map(plan =>
+        plan.subscriptions.length > 0
+          ? this.calculateAvgSubscriptionLength(plan.id)
+          : Promise.resolve(0)
+      );
+
+      const avgLengths = await Promise.all(avgLengthPromises);
+
+      // 결과 조합
+      const byPlan: SubscriptionByPlanDto[] = plans.map((plan, index) => {
+        const subscribers = plan.subscriptions.length;
+        const subscribersThirtyDaysAgo = thirtyDaysAgoCounts[index];
+
+        // 수익 계산
+        let revenue = 0;
+        for (const sub of plan.subscriptions) {
+          if (sub.billingCycle === 'monthly') {
+            revenue += sub.amount * 12; // 연간 수익으로 환산
+          } else if (sub.billingCycle === 'yearly') {
+            revenue += sub.amount;
+          }
+        }
+
+        return {
+          planId: plan.id,
+          planName: plan.name,
+          subscribers,
+          revenue,
+          change: this.calculateChangeRate(subscribersThirtyDaysAgo, subscribers),
+          percentage: totalSubscribers > 0
+            ? Math.round((subscribers / totalSubscribers) * 100 * 10) / 10
+            : 0,
+          avgSubscriptionLengthDays: avgLengths[index],
+        };
+      });
+
+      return { data: byPlan };
+    } catch (error) {
+      this.logger.error('Failed to get by-plan analysis', error);
+      throw new InternalServerErrorException('요금제별 분석 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 평균 구독 기간 계산 (일 단위)
+   */
+  private async calculateAvgSubscriptionLength(planId: string): Promise<number> {
+    const subscriptions = await this.prisma.subscription.findMany({
+      where: {
+        planId,
+        status: 'active',
+        cancelledAt: null,
+      },
+      select: { createdAt: true },
+    });
+
+    if (subscriptions.length === 0) return 0;
+
+    const now = new Date();
+    const totalDays = subscriptions.reduce((sum, sub) => {
+      const days = Math.floor((now.getTime() - sub.createdAt.getTime()) / (1000 * 60 * 60 * 24));
+      return sum + days;
+    }, 0);
+
+    return Math.round(totalDays / subscriptions.length);
+  }
+
+  /**
+   * 5.4 이탈 분석
+   * GET /api/admin/subscriptions/churn
+   */
+  async getChurn(query: SubscriptionStatsQueryDto): Promise<{ data: ChurnAnalysisDto }> {
+    this.logger.debug(`getChurn period=${query.period}`);
+
+    try {
+      const now = new Date();
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+      // 최근 30일간 취소된 구독
+      const churnedSubscriptions = await this.prisma.subscription.findMany({
+        where: {
+          status: 'cancelled',
+          cancelledAt: { gte: thirtyDaysAgo },
+        },
+        include: { plan: true },
+      });
+
+      const totalChurned = churnedSubscriptions.length;
+
+      // 현재 활성 구독자 수 (status가 'active'이고 cancelledAt이 null)
+      const activeSubscriptions = await this.prisma.subscription.count({
+        where: {
+          status: 'active',
+          cancelledAt: null,
+        },
+      });
+
+      // 이탈률 계산
+      const churnRate = activeSubscriptions > 0
+        ? (totalChurned / activeSubscriptions) * 100
+        : 0;
+
+      // 손실 수익 계산
+      let revenueLost = 0;
+      for (const sub of churnedSubscriptions) {
+        if (sub.billingCycle === 'monthly') {
+          revenueLost += sub.amount;
+        } else if (sub.billingCycle === 'yearly') {
+          revenueLost += Math.round(sub.amount / 12);
+        }
+      }
+
+      // 취소 사유별 집계
+      const reasonMap = new Map<string, number>();
+      for (const sub of churnedSubscriptions) {
+        const reason = sub.cancelReason || 'other';
+        reasonMap.set(reason, (reasonMap.get(reason) || 0) + 1);
+      }
+
+      const reasons = Array.from(reasonMap.entries()).map(([reason, count]) => ({
+        reason,
+        label: this.getReasonLabel(reason),
+        count,
+        percentage: totalChurned > 0 ? Math.round((count / totalChurned) * 100 * 10) / 10 : 0,
+      }));
+
+      // 요금제별 이탈 분석
+      const planChurnMap = new Map<string, { churned: number; planName: string }>();
+      for (const sub of churnedSubscriptions) {
+        const key = sub.planId;
+        const existing = planChurnMap.get(key) || { churned: 0, planName: sub.plan.name };
+        planChurnMap.set(key, {
+          churned: existing.churned + 1,
+          planName: existing.planName,
+        });
+      }
+
+      const byPlan = [];
+      for (const [planId, data] of planChurnMap.entries()) {
+        // 30일 전 시점의 활성 구독자 수로 이탈률 계산
+        const planActiveCountThirtyDaysAgo = await this.prisma.subscription.count({
+          where: {
+            planId,
+            status: 'active',
+            createdAt: { lte: thirtyDaysAgo },
+            OR: [
+              { cancelledAt: null },
+              { cancelledAt: { gt: thirtyDaysAgo } },
+            ],
+          },
+        });
+
+        byPlan.push({
+          planId,
+          planName: data.planName,
+          churned: data.churned,
+          churnRate: planActiveCountThirtyDaysAgo > 0
+            ? Math.round((data.churned / planActiveCountThirtyDaysAgo) * 100 * 10) / 10
+            : 0,
+        });
+      }
+
+      const churn = new ChurnAnalysisDto({
+        totalChurned,
+        churnRate: Math.round(churnRate * 10) / 10,
+        revenueLost,
+        reasons,
+        byPlan,
+      });
+
+      return { data: churn };
+    } catch (error) {
+      this.logger.error('Failed to get churn analysis', error);
+      throw new InternalServerErrorException('이탈 분석 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 취소 사유 라벨 변환
+   */
+  private getReasonLabel(reason: string): string {
+    const labels: Record<string, string> = {
+      price: '가격',
+      features: '기능 부족',
+      quality: '서비스 품질',
+      not_using: '사용하지 않음',
+      other: '기타',
+    };
+    return labels[reason] || reason;
+  }
+
+  /**
+   * 5.5 구독 목록 조회
+   * GET /api/admin/subscriptions
+   */
+  async getSubscriptions(query: SubscriptionListQueryDto): Promise<{ data: SubscriptionItemDto[]; pagination: PaginationDto }> {
+    this.logger.debug(`getSubscriptions query=${JSON.stringify(query)}`);
+
+    try {
+      const { page = 1, limit = 20, status, planId } = query;
+
+      if (page < 1 || limit < 1) {
+        throw new BadRequestException('잘못된 페이지 파라미터입니다.');
+      }
+
+      const where: any = {};
+      if (status) {
+        where.status = status;
+      }
+      if (planId) {
+        where.planId = planId;
+      }
+
+      const skip = (page - 1) * limit;
+
+      // 구독 목록과 총 개수 병렬 조회
+      const [subscriptions, total] = await Promise.all([
+        this.prisma.subscription.findMany({
+          where,
+          skip,
+          take: limit,
+          orderBy: { createdAt: 'desc' },
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                displayName: true,
+              },
+            },
+            plan: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        }),
+        this.prisma.subscription.count({ where }),
+      ]);
+
+      const data: SubscriptionItemDto[] = subscriptions.map((sub) => ({
+        id: sub.id,
+        userId: sub.userId,
+        userName: sub.user.displayName,
+        userEmail: sub.user.email,
+        planId: sub.planId,
+        planName: sub.plan.name,
+        status: sub.status,
+        amount: sub.amount,
+        billingCycle: sub.billingCycle,
+        currentPeriodStart: sub.currentPeriodStart.toISOString(),
+        currentPeriodEnd: sub.currentPeriodEnd.toISOString(),
+        createdAt: sub.createdAt.toISOString(),
+      }));
+
+      const totalPages = Math.max(Math.ceil(total / limit), 1);
+      const pagination = new PaginationDto({
+        page,
+        pageSize: limit,
+        total,
+        totalPages,
+      });
+
+      return { data, pagination };
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error('Failed to get subscriptions', error);
+      throw new InternalServerErrorException('구독 목록 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 5.6 요금제 분포
+   * GET /api/admin/subscriptions/distribution
+   */
+  async getDistribution(): Promise<{ data: PlanDistributionDto[] }> {
+    this.logger.debug('getDistribution');
+
+    try {
+      // 모든 활성 요금제 조회
+      const plans = await this.prisma.plan.findMany({
+        where: { status: 'active' },
+        include: {
+          subscriptions: {
+            where: {
+              status: 'active',
+              cancelledAt: null,
+            },
+          },
+        },
+      });
+
+      // 전체 활성 구독자 수
+      const totalSubscribers = await this.prisma.subscription.count({
+        where: {
+          status: 'active',
+          cancelledAt: null,
+        },
+      });
+
+      const distribution: PlanDistributionDto[] = plans.map((plan) => ({
+        planId: plan.id,
+        planName: plan.name,
+        userCount: plan.subscriptions.length,
+        percentage: totalSubscribers > 0
+          ? Math.round((plan.subscriptions.length / totalSubscribers) * 100 * 10) / 10
+          : 0,
+      }));
+
+      return { data: distribution };
+    } catch (error) {
+      this.logger.error('Failed to get distribution', error);
+      throw new InternalServerErrorException('요금제 분포 조회에 실패했습니다.');
+    }
+  }
+}
+

--- a/backend/src/modules/admin/users.controller.ts
+++ b/backend/src/modules/admin/users.controller.ts
@@ -1,0 +1,218 @@
+import { Controller, Get, Patch, Post, Query, Param, Body, UseGuards, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from './guards';
+import { AdminOnlyGuard } from './guards/admin-only.guard';
+import { UsersService } from './users.service';
+import {
+  UserListQueryDto,
+  UserListResponseDto,
+  UserDetailResponseDto,
+  UpdateUserRoleDto,
+  UpdateUserRoleResponseDto,
+  SuspendUserDto,
+  BanUserDto,
+  UserStatusResponseDto,
+} from './dto';
+
+/**
+ * Users Controller (Admin)
+ * Base URL: /api/admin/users
+ * 
+ * 관리자용 사용자 관리
+ */
+@ApiTags('Admin')
+@ApiBearerAuth()
+@Controller('admin/users')
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+export class UsersController {
+  private readonly logger = new Logger(UsersController.name);
+
+  constructor(private readonly usersService: UsersService) {}
+
+  /**
+   * 사용자 목록 조회
+   * GET /api/admin/users
+   */
+  @Get()
+  @ApiOperation({
+    summary: '사용자 목록 조회',
+    description: '필터링, 검색, 정렬, 페이지네이션을 지원하는 사용자 목록 조회',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자 목록 조회 성공',
+    type: UserListResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '권한 부족 (admin 또는 operator 역할 필요)',
+  })
+  async getUsers(@Query() query: UserListQueryDto): Promise<UserListResponseDto> {
+    this.logger.debug(`GET /api/admin/users query=${JSON.stringify(query)}`);
+    return await this.usersService.getUsers(query);
+  }
+
+  /**
+   * 사용자 상세 조회
+   * GET /api/admin/users/:userId
+   */
+  @Get(':userId')
+  @ApiOperation({
+    summary: '사용자 상세 조회',
+    description: '특정 사용자의 상세 정보, 통계, 최근 활동을 조회합니다.',
+  })
+  @ApiParam({
+    name: 'userId',
+    description: '사용자 ID',
+    example: 'user-001',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자 상세 조회 성공',
+    type: UserDetailResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '권한 부족 (admin 또는 operator 역할 필요)',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자를 찾을 수 없음',
+  })
+  async getUserDetail(@Param('userId') userId: string): Promise<UserDetailResponseDto> {
+    this.logger.debug(`GET /api/admin/users/${userId}`);
+    return await this.usersService.getUserDetail(userId);
+  }
+
+  /**
+   * 사용자 역할 변경
+   * PATCH /api/admin/users/:userId/role
+   */
+  @Patch(':userId/role')
+  @UseGuards(JwtAuthGuard, AdminOnlyGuard) // admin만 가능
+  @ApiOperation({
+    summary: '사용자 역할 변경',
+    description: '사용자의 역할을 변경합니다. (admin 권한 필요)',
+  })
+  @ApiParam({
+    name: 'userId',
+    description: '사용자 ID',
+    example: 'user-001',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '역할 변경 성공',
+    type: UpdateUserRoleResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 (이미 동일한 역할)',
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '권한 부족 (admin 권한 필요)',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자를 찾을 수 없음',
+  })
+  async updateUserRole(
+    @Param('userId') userId: string,
+    @Body() dto: UpdateUserRoleDto,
+  ): Promise<{ data: UpdateUserRoleResponseDto }> {
+    this.logger.debug(`PATCH /api/admin/users/${userId}/role role=${dto.role}`);
+    const result = await this.usersService.updateUserRole(userId, dto);
+    return { data: result };
+  }
+
+  /**
+   * 사용자 일시 정지
+   * POST /api/admin/users/:userId/suspend
+   */
+  @Post(':userId/suspend')
+  @UseGuards(JwtAuthGuard, AdminOnlyGuard)
+  @ApiOperation({
+    summary: '사용자 일시 정지',
+    description: '사용자를 일시 정지합니다. (admin 권한 필요)',
+  })
+  @ApiParam({ name: 'userId', description: '사용자 ID', example: 'user-001' })
+  @ApiResponse({
+    status: 200,
+    description: '일시 정지 성공',
+    type: UserStatusResponseDto,
+  })
+  @ApiResponse({ status: 404, description: '사용자를 찾을 수 없음' })
+  async suspendUser(
+    @Param('userId') userId: string,
+    @Body() dto: SuspendUserDto,
+  ): Promise<{ data: UserStatusResponseDto }> {
+    this.logger.debug(`POST /api/admin/users/${userId}/suspend`);
+    const result = await this.usersService.suspendUser(userId, dto);
+    return { data: result };
+  }
+
+  /**
+   * 사용자 영구 차단
+   * POST /api/admin/users/:userId/ban
+   */
+  @Post(':userId/ban')
+  @UseGuards(JwtAuthGuard, AdminOnlyGuard)
+  @ApiOperation({
+    summary: '사용자 영구 차단',
+    description: '사용자를 영구 차단합니다. (admin 권한 필요)',
+  })
+  @ApiParam({ name: 'userId', description: '사용자 ID', example: 'user-001' })
+  @ApiResponse({
+    status: 200,
+    description: '영구 차단 성공',
+    type: UserStatusResponseDto,
+  })
+  @ApiResponse({ status: 404, description: '사용자를 찾을 수 없음' })
+  async banUser(
+    @Param('userId') userId: string,
+    @Body() dto: BanUserDto,
+  ): Promise<{ data: UserStatusResponseDto }> {
+    this.logger.debug(`POST /api/admin/users/${userId}/ban`);
+    const result = await this.usersService.banUser(userId, dto);
+    return { data: result };
+  }
+
+  /**
+   * 사용자 활성화 (정지/차단 해제)
+   * POST /api/admin/users/:userId/activate
+   */
+  @Post(':userId/activate')
+  @UseGuards(JwtAuthGuard, AdminOnlyGuard)
+  @ApiOperation({
+    summary: '사용자 활성화',
+    description: '정지 또는 차단된 사용자를 활성화합니다. (admin 권한 필요)',
+  })
+  @ApiParam({ name: 'userId', description: '사용자 ID', example: 'user-001' })
+  @ApiResponse({
+    status: 200,
+    description: '활성화 성공',
+    type: UserStatusResponseDto,
+  })
+  @ApiResponse({ status: 404, description: '사용자를 찾을 수 없음' })
+  async activateUser(
+    @Param('userId') userId: string,
+  ): Promise<{ data: UserStatusResponseDto }> {
+    this.logger.debug(`POST /api/admin/users/${userId}/activate`);
+    const result = await this.usersService.activateUser(userId);
+    return { data: result };
+  }
+}
+

--- a/backend/src/modules/admin/users.service.spec.ts
+++ b/backend/src/modules/admin/users.service.spec.ts
@@ -1,0 +1,297 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { PrismaService } from '../db/prisma.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let prismaService: any;
+
+  beforeEach(async () => {
+    const mockPrismaService = {
+      user: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        count: jest.fn(),
+        update: jest.fn(),
+      },
+      folder: {
+        count: jest.fn(),
+      },
+      note: {
+        count: jest.fn(),
+      },
+      upload: {
+        count: jest.fn(),
+        aggregate: jest.fn(),
+      },
+      auditLog: {
+        count: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn(),
+      },
+      refreshToken: {
+        findFirst: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    prismaService = module.get(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getUsers', () => {
+    it('should return paginated user list', async () => {
+      const mockUsers = [
+        {
+          id: 'user-001',
+          email: 'user1@test.com',
+          displayName: 'User 1',
+          picture: null,
+          role: 'user',
+          createdAt: new Date(),
+          deletedAt: null,
+          isBanned: false,
+          banReason: null,
+          suspendedUntil: null,
+          refreshTokens: [{ createdAt: new Date() }],
+          subscriptions: [],
+        },
+      ];
+
+      prismaService.user.findMany.mockResolvedValue(mockUsers as any);
+      prismaService.user.count.mockResolvedValue(100);
+
+      const result = await service.getUsers({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.pagination.total).toBe(100);
+      expect(result.pagination.page).toBe(1);
+      expect(result.pagination.pageSize).toBe(20);
+      expect(result.pagination.totalPages).toBe(5);
+    });
+
+    it('should throw BadRequestException for invalid page', async () => {
+      await expect(service.getUsers({ page: 0, limit: 20 })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException for invalid limit', async () => {
+      await expect(service.getUsers({ page: 1, limit: -1 })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should filter by role', async () => {
+      prismaService.user.findMany.mockResolvedValue([]);
+      prismaService.user.count.mockResolvedValue(0);
+
+      await service.getUsers({ page: 1, limit: 20, role: 'admin' });
+
+      expect(prismaService.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({ role: 'admin' }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should search by email or name', async () => {
+      prismaService.user.findMany.mockResolvedValue([]);
+      prismaService.user.count.mockResolvedValue(0);
+
+      await service.getUsers({ page: 1, limit: 20, search: 'test' });
+
+      expect(prismaService.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                OR: expect.any(Array),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('getUserDetail', () => {
+    it('should return user detail with stats', async () => {
+      const mockUser = {
+        id: 'user-001',
+        email: 'user@test.com',
+        displayName: 'Test User',
+        picture: null,
+        role: 'user',
+        createdAt: new Date(),
+        deletedAt: null,
+        refreshTokens: [{ createdAt: new Date() }],
+      };
+
+      prismaService.user.findUnique.mockResolvedValue(mockUser as any);
+      prismaService.folder.count.mockResolvedValue(10);
+      prismaService.upload.count.mockResolvedValue(5);
+      prismaService.upload.aggregate.mockResolvedValue({
+        _sum: { totalSizeBytes: 1024000000 },
+      } as any);
+      prismaService.auditLog.count.mockResolvedValue(50);
+      prismaService.auditLog.findMany.mockResolvedValue([]);
+
+      const result = await service.getUserDetail('user-001');
+
+      expect(result.data.id).toBe('user-001');
+      expect(result.data.stats.notesCount).toBe(10);
+      expect(result.data.stats.storageUsedMb).toBe(977); // 1024000000 bytes = 977 MB
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      prismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getUserDetail('non-existent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException when user is deleted', async () => {
+      prismaService.user.findUnique.mockResolvedValue({
+        id: 'user-001',
+        deletedAt: new Date(),
+      } as any);
+
+      await expect(service.getUserDetail('user-001')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateUserRole', () => {
+    it('should update user role successfully', async () => {
+      const mockUser = {
+        id: 'user-001',
+        role: 'user',
+        deletedAt: null,
+      };
+
+      prismaService.user.findUnique.mockResolvedValue(mockUser as any);
+      prismaService.user.update.mockResolvedValue({
+        ...mockUser,
+        role: 'admin',
+      } as any);
+
+      const result = await service.updateUserRole('user-001', { role: 'admin' });
+
+      expect(result.id).toBe('user-001');
+      expect(result.role).toBe('admin');
+      expect(prismaService.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-001' },
+        data: { role: 'admin' },
+        select: { id: true, role: true },
+      });
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      prismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateUserRole('non-existent', { role: 'admin' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when role is same', async () => {
+      prismaService.user.findUnique.mockResolvedValue({
+        id: 'user-001',
+        role: 'admin',
+        deletedAt: null,
+      } as any);
+
+      await expect(
+        service.updateUserRole('user-001', { role: 'admin' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('suspendUser', () => {
+    it('should suspend user successfully', async () => {
+      prismaService.user.findUnique.mockResolvedValue({
+        id: 'user-001',
+        deletedAt: null,
+      } as any);
+      prismaService.auditLog.create.mockResolvedValue({} as any);
+
+      const suspendUntil = new Date('2024-12-31');
+      const result = await service.suspendUser('user-001', {
+        reason: 'Test reason',
+        suspendUntil: suspendUntil.toISOString(),
+      });
+
+      expect(result.id).toBe('user-001');
+      expect(result.status).toBe('suspended');
+      expect(result.suspendedUntil).toBe(suspendUntil.toISOString());
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      prismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.suspendUser('non-existent', {
+          reason: 'Test',
+          suspendUntil: new Date().toISOString(),
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('banUser', () => {
+    it('should ban user successfully', async () => {
+      prismaService.user.findUnique.mockResolvedValue({
+        id: 'user-001',
+        deletedAt: null,
+      } as any);
+      prismaService.auditLog.create.mockResolvedValue({} as any);
+
+      const result = await service.banUser('user-001', {
+        reason: 'Violation',
+      });
+
+      expect(result.id).toBe('user-001');
+      expect(result.status).toBe('banned');
+      expect(result.banReason).toBe('Violation');
+    });
+  });
+
+  describe('activateUser', () => {
+    it('should activate user successfully', async () => {
+      prismaService.user.findUnique.mockResolvedValue({
+        id: 'user-001',
+        deletedAt: null,
+      } as any);
+      prismaService.auditLog.create.mockResolvedValue({} as any);
+
+      const result = await service.activateUser('user-001');
+
+      expect(result.id).toBe('user-001');
+      expect(result.status).toBe('active');
+      expect(result.suspendedUntil).toBeNull();
+      expect(result.banReason).toBeNull();
+    });
+  });
+});
+

--- a/backend/src/modules/admin/users.service.ts
+++ b/backend/src/modules/admin/users.service.ts
@@ -1,0 +1,654 @@
+import { Injectable, Logger, InternalServerErrorException, NotFoundException, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../db/prisma.service';
+import {
+  UserListQueryDto,
+  UserListResponseDto,
+  UserListItemDto,
+  PaginationDto,
+  UserDetailResponseDto,
+  UserDetailDto,
+  UserStatsDto,
+  RecentActivityDto,
+  UpdateUserRoleDto,
+  UpdateUserRoleResponseDto,
+  SuspendUserDto,
+  BanUserDto,
+  UserStatusResponseDto,
+} from './dto';
+
+@Injectable()
+export class UsersService {
+  private readonly logger = new Logger(UsersService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 사용자 목록 조회
+   * GET /api/admin/users
+   */
+  async getUsers(query: UserListQueryDto): Promise<UserListResponseDto> {
+    this.logger.debug(`getUsers query=${JSON.stringify(query)}`);
+
+    try {
+      const {
+        page = 1,
+        limit = 20,
+        role,
+        status,
+        search,
+        sortBy = 'createdAt',
+        sortOrder = 'desc',
+      } = query;
+
+      // 안전성 체크
+      if (page < 1 || limit < 1) {
+        throw new BadRequestException('잘못된 페이지 파라미터입니다.');
+      }
+
+      // Where 조건 구성 (AND로 안전하게 결합)
+      const where: any = {
+        deletedAt: null,
+      };
+
+      const andConditions: any[] = [];
+
+      // 역할 필터
+      if (role) {
+        andConditions.push({ role });
+      }
+
+      // 상태 필터
+      if (status === 'inactive') {
+        const thirtyDaysAgo = new Date();
+        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+        andConditions.push({
+          refreshTokens: {
+            none: {
+              createdAt: { gte: thirtyDaysAgo },
+            },
+          },
+        });
+      } else if (status === 'suspended') {
+        // 일시 정지 상태: suspendedUntil이 현재 시간보다 미래
+        andConditions.push({
+          suspendedUntil: {
+            gt: new Date(),
+          },
+        });
+      } else if (status === 'banned') {
+        // 영구 차단 상태
+        andConditions.push({
+          isBanned: true,
+        });
+      } else if (status === 'active') {
+        // 활성 상태: 차단/정지되지 않고, 최근 30일 이내 활동
+        const thirtyDaysAgo = new Date();
+        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+        andConditions.push({
+          isBanned: false,
+          OR: [
+            { suspendedUntil: null },
+            { suspendedUntil: { lte: new Date() } },
+          ],
+        });
+        andConditions.push({
+          refreshTokens: {
+            some: {
+              createdAt: { gte: thirtyDaysAgo },
+            },
+          },
+        });
+      }
+
+      // 검색 (이름 또는 이메일) - OR 조건은 별도로
+      if (search) {
+        andConditions.push({
+          OR: [
+            { displayName: { contains: search, mode: 'insensitive' } },
+            { email: { contains: search, mode: 'insensitive' } },
+          ],
+        });
+      }
+
+      // AND 조건 적용
+      if (andConditions.length > 0) {
+        where.AND = andConditions;
+      }
+
+      // 정렬 설정
+      const orderBy: any = {};
+      if (sortBy === 'name') {
+        orderBy.displayName = sortOrder;
+      } else {
+        orderBy.createdAt = sortOrder;
+      }
+
+      // 페이지네이션 계산
+      const skip = (page - 1) * limit;
+
+      // 병렬로 데이터와 총 개수 조회
+      const [users, total] = await Promise.all([
+        this.prisma.user.findMany({
+          where,
+          orderBy,
+          skip,
+          take: limit,
+          select: {
+            id: true,
+            email: true,
+            displayName: true,
+            role: true,
+            createdAt: true,
+            isBanned: true,
+            banReason: true,
+            suspendedUntil: true,
+            refreshTokens: {
+              orderBy: { createdAt: 'desc' },
+              take: 1,
+              select: { createdAt: true },
+            },
+            subscriptions: {
+              where: {
+                status: 'active',
+                cancelledAt: null,
+              },
+              take: 1,
+              orderBy: { createdAt: 'desc' },
+              select: {
+                planId: true,
+                plan: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+                status: true,
+              },
+            },
+          },
+        }),
+        this.prisma.user.count({ where }),
+      ]);
+
+      // DTO 변환
+      const data = users.map((user) => {
+        const lastLogin = user.refreshTokens[0]?.createdAt;
+        const status = this.determineUserStatus(lastLogin, user.isBanned, user.suspendedUntil);
+
+        // 활성 구독 정보 가져오기
+        const activeSubscription = user.subscriptions[0];
+        const subscription = activeSubscription
+          ? {
+              planId: activeSubscription.planId,
+              planName: activeSubscription.plan.name,
+              status: activeSubscription.status,
+            }
+          : undefined;
+
+        return new UserListItemDto({
+          id: user.id,
+          email: user.email,
+          name: user.displayName,
+          picture: undefined,
+          role: user.role,
+          status,
+          createdAt: user.createdAt.toISOString(),
+          lastLoginAt: lastLogin?.toISOString(),
+          suspendedUntil: user.suspendedUntil?.toISOString() || null,
+          banReason: user.banReason || null,
+          subscription,
+        });
+      });
+
+      // 페이지네이션 정보
+      const totalPages = Math.max(Math.ceil(total / limit), 1);
+      const pagination = new PaginationDto({
+        page,
+        pageSize: limit,
+        total,
+        totalPages,
+      });
+
+      return new UserListResponseDto({ data, pagination });
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error('Failed to get users', error);
+      throw new InternalServerErrorException('사용자 목록 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 사용자 상태 판단
+   */
+  private determineUserStatus(
+    lastLoginAt: Date | null | undefined,
+    isBanned: boolean,
+    suspendedUntil: Date | null | undefined
+  ): string {
+    // 영구 차단
+    if (isBanned) {
+      return 'banned';
+    }
+
+    // 일시 정지 (정지 기간이 아직 남아있으면)
+    if (suspendedUntil && new Date() < suspendedUntil) {
+      return 'suspended';
+    }
+
+    if (!lastLoginAt) {
+      return 'inactive';
+    }
+
+    // 30일 이상 로그인하지 않은 경우
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    
+    if (lastLoginAt < thirtyDaysAgo) {
+      return 'inactive';
+    }
+
+    return 'active';
+  }
+
+  /**
+   * 사용자 상세 조회
+   * GET /api/admin/users/:userId
+   */
+  async getUserDetail(userId: string): Promise<UserDetailResponseDto> {
+    this.logger.debug(`getUserDetail userId=${userId}`);
+
+    try {
+      // 사용자 기본 정보 조회
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          email: true,
+          displayName: true,
+          role: true,
+          createdAt: true,
+          deletedAt: true,
+          isBanned: true,
+          banReason: true,
+          suspendedUntil: true,
+          refreshTokens: {
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+            select: { createdAt: true },
+          },
+        },
+      });
+
+      if (!user || user.deletedAt) {
+        throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      }
+
+      // 통계 정보 병렬 조회
+      const [foldersCount, uploadsCount, uploadsSize, auditLogsCount] = await Promise.all([
+        // 노트 수 (Folder 수로 대체)
+        this.prisma.folder.count({
+          where: {
+            userId,
+            deletedAt: null,
+          },
+        }),
+
+        // 업로드 파일 수
+        this.prisma.upload.count({
+          where: {
+            userId,
+          },
+        }),
+
+        // 스토리지 사용량 (bytes → MB)
+        this.prisma.upload.aggregate({
+          where: {
+            userId,
+          },
+          _sum: {
+            totalSizeBytes: true,
+          },
+        }),
+
+        // 활동 수 (AuditLog 수)
+        this.prisma.auditLog.count({
+          where: { userId },
+        }),
+      ]);
+
+      // 최근 활동 조회 (최근 10개)
+      const recentAuditLogs = await this.prisma.auditLog.findMany({
+        where: { userId },
+        orderBy: { at: 'desc' },
+        take: 10,
+        select: {
+          id: true,
+          method: true,
+          path: true,
+          at: true,
+        },
+      });
+
+      // 상태 판단
+      const lastLogin = user.refreshTokens[0]?.createdAt;
+      const status = this.determineUserStatus(lastLogin, user.isBanned, user.suspendedUntil);
+
+      // 스토리지 MB 변환
+      const storageMb = uploadsSize._sum?.totalSizeBytes
+        ? Math.round(uploadsSize._sum.totalSizeBytes / (1024 * 1024))
+        : 0;
+
+      // 통계 생성
+      const stats = new UserStatsDto({
+        notesCount: foldersCount,
+        sessionsCount: auditLogsCount,
+        totalUsageHours: 0,
+        storageUsedMb: storageMb,
+      });
+
+      // 최근 활동 변환
+      const recentActivities = recentAuditLogs.map((log) => {
+        const type = this.determineActivityType(log.method, log.path);
+        const description = this.getActivityDescription(type, log.method, log.path);
+
+        return new RecentActivityDto({
+          id: log.id,
+          type,
+          description,
+          createdAt: log.at.toISOString(),
+          metadata: {
+            method: log.method,
+            path: log.path,
+          },
+        });
+      });
+
+      // 상세 정보 생성
+      const detail = new UserDetailDto({
+        id: user.id,
+        email: user.email,
+        name: user.displayName,
+        picture: undefined,
+        role: user.role,
+        status,
+        createdAt: user.createdAt.toISOString(),
+        lastLoginAt: lastLogin?.toISOString(),
+        stats,
+        recentActivities,
+      });
+
+      return new UserDetailResponseDto({ data: detail });
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error('Failed to get user detail', error);
+      throw new InternalServerErrorException('사용자 상세 조회에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 활동 타입 판단
+   */
+  private determineActivityType(method: string | null, path: string | null): string {
+    if (!method || !path) return 'login';
+
+    if (path.includes('/auth/')) return 'login';
+    if (path.includes('/folders') && method === 'POST') return 'note_create';
+    if (path.includes('/upload')) return 'file_upload';
+    if (path.includes('/sessions')) return 'session_join';
+
+    return 'login';
+  }
+
+  /**
+   * 활동 설명 생성
+   */
+  private getActivityDescription(type: string, method: string | null, path: string | null): string {
+    switch (type) {
+      case 'login':
+        return '로그인';
+      case 'note_create':
+        return '노트 생성';
+      case 'file_upload':
+        return '파일 업로드';
+      case 'session_join':
+        return '세션 참여';
+      default:
+        return `${method} ${path}`;
+    }
+  }
+
+  /**
+   * 사용자 역할 변경
+   * PATCH /api/admin/users/:userId/role
+   */
+  async updateUserRole(
+    userId: string,
+    dto: UpdateUserRoleDto,
+  ): Promise<UpdateUserRoleResponseDto> {
+    this.logger.debug(`updateUserRole userId=${userId} role=${dto.role}`);
+
+    try {
+      // 사용자 존재 확인
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          role: true,
+          deletedAt: true,
+        },
+      });
+
+      if (!user || user.deletedAt) {
+        throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      }
+
+      // 동일한 역할로 변경 시도 체크
+      if (user.role === dto.role) {
+        throw new BadRequestException('이미 동일한 역할입니다.');
+      }
+
+      // 역할 업데이트
+      const updated = await this.prisma.user.update({
+        where: { id: userId },
+        data: { role: dto.role },
+        select: {
+          id: true,
+          role: true,
+        },
+      });
+
+      this.logger.log(`User role updated: ${userId} -> ${dto.role}`);
+
+      return new UpdateUserRoleResponseDto({
+        id: updated.id,
+        role: updated.role,
+      });
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error('Failed to update user role', error);
+      throw new InternalServerErrorException('사용자 역할 변경에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 사용자 일시 정지
+   * POST /api/admin/users/:userId/suspend
+   */
+  async suspendUser(userId: string, dto: SuspendUserDto): Promise<UserStatusResponseDto> {
+    this.logger.debug(`suspendUser userId=${userId} until=${dto.suspendUntil}`);
+
+    try {
+      // 사용자 존재 확인 및 정지 처리
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, deletedAt: true },
+      });
+
+      if (!user || user.deletedAt) {
+        throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      }
+
+      // DB에 실제 정지 상태 업데이트
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: {
+          suspendedUntil: new Date(dto.suspendUntil),
+        },
+      });
+
+      // AuditLog에 정지 기록 추가
+      await this.prisma.auditLog.create({
+        data: {
+          userId,
+          method: 'SUSPEND',
+          path: '/admin/suspend',
+          action: 'USER_SUSPEND',
+          resourceId: userId,
+          payload: {
+            reason: dto.reason,
+            suspendUntil: dto.suspendUntil,
+          },
+        },
+      });
+
+      this.logger.log(`User suspended: ${userId} until ${dto.suspendUntil}`);
+
+      return new UserStatusResponseDto({
+        id: userId,
+        status: 'suspended',
+        suspendedUntil: dto.suspendUntil,
+        banReason: null,
+      });
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error('Failed to suspend user', error);
+      throw new InternalServerErrorException('사용자 정지에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 사용자 영구 차단
+   * POST /api/admin/users/:userId/ban
+   */
+  async banUser(userId: string, dto: BanUserDto): Promise<UserStatusResponseDto> {
+    this.logger.debug(`banUser userId=${userId} reason=${dto.reason}`);
+
+    try {
+      // 사용자 존재 확인 및 차단 처리
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, deletedAt: true },
+      });
+
+      if (!user || user.deletedAt) {
+        throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      }
+
+      // DB에 실제 차단 상태 업데이트
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: {
+          isBanned: true,
+          banReason: dto.reason,
+        },
+      });
+
+      // AuditLog에 차단 기록 추가
+      await this.prisma.auditLog.create({
+        data: {
+          userId,
+          method: 'BAN',
+          path: '/admin/ban',
+          action: 'USER_BAN',
+          resourceId: userId,
+          payload: {
+            reason: dto.reason,
+          },
+        },
+      });
+
+      this.logger.log(`User banned: ${userId} reason=${dto.reason}`);
+
+      return new UserStatusResponseDto({
+        id: userId,
+        status: 'banned',
+        suspendedUntil: null,
+        banReason: dto.reason,
+      });
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error('Failed to ban user', error);
+      throw new InternalServerErrorException('사용자 차단에 실패했습니다.');
+    }
+  }
+
+  /**
+   * 사용자 활성화 (정지/차단 해제)
+   * POST /api/admin/users/:userId/activate
+   */
+  async activateUser(userId: string): Promise<UserStatusResponseDto> {
+    this.logger.debug(`activateUser userId=${userId}`);
+
+    try {
+      // 사용자 존재 확인 및 활성화 처리
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, deletedAt: true },
+      });
+
+      if (!user || user.deletedAt) {
+        throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      }
+
+      // DB에 실제 활성화 상태 업데이트
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: {
+          isBanned: false,
+          banReason: null,
+          suspendedUntil: null,
+        },
+      });
+
+      // AuditLog에 활성화 기록 추가
+      await this.prisma.auditLog.create({
+        data: {
+          userId,
+          method: 'ACTIVATE',
+          path: '/admin/activate',
+          action: 'USER_ACTIVATE',
+          resourceId: userId,
+          payload: {
+            action: 'activate',
+          },
+        },
+      });
+
+      this.logger.log(`User activated: ${userId}`);
+
+      return new UserStatusResponseDto({
+        id: userId,
+        status: 'active',
+        suspendedUntil: null,
+        banReason: null,
+      });
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error('Failed to activate user', error);
+      throw new InternalServerErrorException('사용자 활성화에 실패했습니다.');
+    }
+  }
+}
+

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -24,6 +24,7 @@ import { LiveblocksModule } from './liveblocks/liveblocks.module';
 import { SharingModule } from './sharing/sharing.module';
 import { EmailModule } from './email/email.module';
 import { AiModule } from './ai/ai.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -53,6 +54,7 @@ import { AiModule } from './ai/ai.module';
     SharingModule,
     EmailModule,
     AiModule,
+    AdminModule,
   ],
   controllers: [RootController],
   providers: [

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ScheduleModule } from '@nestjs/schedule';
 import { UsersModule } from '../users/users.module';
+import { DbModule } from '../db/db.module';
 import { AuthService } from './services/auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
@@ -18,6 +19,7 @@ import { AuthConfig } from './config/auth.config';
 @Module({
   imports: [
     UsersModule,
+    DbModule,
     PassportModule,
     ScheduleModule.forRoot(), // Enable scheduled tasks
     JwtModule.register({

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -3,10 +3,16 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { JwtBlacklistService } from '../services/jwt-blacklist.service';
 import { AuthConfig } from '../config/auth.config';
+import { PrismaService } from '../../db/prisma.service';
+import { AuthCacheService } from '../services/auth-cache.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private readonly jwtBlacklistService: JwtBlacklistService) {
+  constructor(
+    private readonly jwtBlacklistService: JwtBlacklistService,
+    private readonly prisma: PrismaService,
+    private readonly cache: AuthCacheService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -21,6 +27,42 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       if (isBlacklisted) {
         throw new UnauthorizedException('Token has been revoked');
       }
+    }
+    
+    // Check if user is banned or suspended (with caching)
+    const cacheKey = `user:ban-suspend:${payload.sub}`;
+    const userStatus = await this.cache.getOrCompute(
+      cacheKey,
+      async () => {
+        const user = await this.prisma.user.findUnique({
+          where: { id: payload.sub },
+          select: {
+            id: true,
+            isBanned: true,
+            suspendedUntil: true,
+            deletedAt: true,
+          },
+        });
+        
+        return {
+          exists: !!user && !user.deletedAt,
+          isBanned: user?.isBanned || false,
+          suspendedUntil: user?.suspendedUntil?.toISOString() || null,
+        };
+      },
+      300, // 5분 캐시
+    );
+
+    if (!userStatus.exists) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    if (userStatus.isBanned) {
+      throw new UnauthorizedException('Your account has been banned');
+    }
+
+    if (userStatus.suspendedUntil && new Date() < new Date(userStatus.suspendedUntil)) {
+      throw new UnauthorizedException(`Your account is suspended until ${userStatus.suspendedUntil}`);
     }
     
     return { id: payload.sub };

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # ==========================================
 # Bun Alpine Frontend Dockerfile
 # ==========================================


### PR DESCRIPTION
* feat: admin 모듈 구조 생성 및 관리자 정보 조회 api

* fix: refator guards, constants

* fix 타입 안정성 개선

* feat: 대시보드 통계 조회 api

* 대시보드 성능 및 정확도 개선

* feat: 서버상태 조회 api 구현

* feat: 사용자 목록 조회 api

* fix: 타입 오류 수정

* feat: add 사용자 상제 조회

* feat: Add user role API

* feat: 사용자 상태 관리 정지,차단,활성화

* fix: 파라미터 에러 수정

* feat: Add plan management

* chore: 구독료 음수 제한

* feat: add 구독 분석

* fix: 라우트 순서 수정

* feat: 서버 모니터링

* 서버 목록 중복 제거

* fix: storage 타입 오류 수정

* feat: 시스템 설정

* fix: 빌드 에러 수정

* feat: admin 단위 테스트

* fix: 타입 에러

* fix: admin test error

* chore: 도커 신텍스 에러

* fix: 의존성 오류

* fix: swagger 표기 방식

* feat: Add 플랜, 구독 스키마

* fix: 스키마 제약조건 에러

* feat: 서버세팅 스키마 추가 및 유저 정지 기능 구현

* fix: 세팅서비스 오류

* fix: 구독 취소 기능 제거

* fix: 구독 통계 상태 미반영

* fix: 사용자 상태 필터링 구현

* fix: 서버 상태 데이터 개선

* fix: 빌드에러

* fix: test mock data 사용 오류

* fix: jwt strategy test 수정

---------